### PR TITLE
Fix material reset when closing results

### DIFF
--- a/craftparse.js
+++ b/craftparse.js
@@ -128,6 +128,7 @@ function closeResults() {
     resultsDiv.innerHTML = ''; // Tyhjennä aiemmat tulokset
 	document.getElementById('results').style.display = 'none';
 	document.getElementById('generatebychoice').style.display = 'block';
+	initialMaterials = {}; // Reset materials to allow fresh input values
 }
 
 function createCloseButton(parentElement) {


### PR DESCRIPTION
## Summary
- reset `initialMaterials` each time the user closes the results view to allow recalculating with new inputs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684738f927e08322b957ce3856afffb9