### PR TITLE
Clamp negative remaining amounts

### DIFF
--- a/craftparse.js
+++ b/craftparse.js
@@ -271,12 +271,10 @@ function calculateMaterials() {
 		const originalAmount = matchedKey ? initialMaterials[matchedKey] : 0;
 
 		
-		if(originalAmount>0){
-			const remainingAmount = originalAmount - data.amount;
-			if(remainingAmount>=0){
-				pAvailableMaterials.textContent = `${new Intl.NumberFormat('en-US').format(remainingAmount)}`;
-			}
-		}
+                if (originalAmount > 0) {
+                        const remainingAmount = originalAmount - data.amount;
+                        pAvailableMaterials.textContent = `${new Intl.NumberFormat('en-US').format(Math.max(remainingAmount, 0))}`;
+                }
 		
 		
         materialContainer.dataset.material = materialName;


### PR DESCRIPTION
## Summary
- ensure displayed remaining material can't go negative

## Testing
- `node -c craftparse.js`

------
https://chatgpt.com/codex/tasks/task_b_684739d0e78c83228417c7c6a7639cbf