### PR TITLE
Improve CTW section with info popups

### DIFF
--- a/craftparse.js
+++ b/craftparse.js
@@ -64,6 +64,22 @@ document.addEventListener('DOMContentLoaded', function() {
 
         wrapperDiv.style.display = 'block';
     });
+
+    const ctwBtn = document.getElementById('ctwInfoBtn');
+    const ctwPopup = document.getElementById('ctwInfoPopup');
+    ctwBtn?.addEventListener('click', () => {
+        if (ctwPopup) {
+            ctwPopup.style.display = ctwPopup.style.display === 'block' ? 'none' : 'block';
+        }
+    });
+
+    const oddsBtn = document.getElementById('oddsInfoBtn');
+    const oddsPopup = document.getElementById('oddsInfoPopup');
+    oddsBtn?.addEventListener('click', () => {
+        if (oddsPopup) {
+            oddsPopup.style.display = oddsPopup.style.display === 'block' ? 'none' : 'block';
+        }
+    });
 });
 
 function formatPlaceholderWithCommas(number) {

--- a/index.html
+++ b/index.html
@@ -146,9 +146,16 @@
 				</select>
 			</div>
 			
-			<div class="warlord-toggle"><input type="checkbox" id="includeWarlords"><label for="includeWarlords">Include CTW items</label></div>
-                        <div class="warlord-toggle"><input type="checkbox" id="level1OnlyWarlords" checked><label for="level1OnlyWarlords">Use only CTW items for Level 1</label></div>
-			<p class="odds-info">Leaves out the lower-odds items from season 0 + CTW <span>Normal odds level is always included</span></p>
+                        <div class="section-title"><span>Use Ceremonial Targ items</span><button id="ctwInfoBtn" class="info-btn" aria-label="CTW info">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336c-13.3 0-24 10.7-24 24s10.7 24 24 24l80 0c13.3 0 24-10.7 24-24s-10.7-24-24-24l-8 0 0-88c0-13.3-10.7-24-24-24l-48 0c-13.3 0-24 10.7-24 24s10.7 24 24 24l24 0 0 64-24 0zm40-144a32 32 0 1 0 0-64 32 32 0 1 0 0 64z"/></svg>
+                        </button></div>
+                        <div id="ctwInfoPopup" class="info-popup">Ceremonial Targ items are special items from CTW events. "Include in calculations" lets the planner pick them for any level. "Only use for level 1" restricts level 1 to these items, but other levels may still use them.</div>
+                        <div class="warlord-toggle"><input type="checkbox" id="includeWarlords"><label for="includeWarlords">Include in calculations</label></div>
+                        <div class="warlord-toggle"><input type="checkbox" id="level1OnlyWarlords" checked><label for="level1OnlyWarlords">Only use for level 1</label></div>
+                        <div class="section-title"><span>Odds</span><button id="oddsInfoBtn" class="info-btn" aria-label="Odds info">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336c-13.3 0-24 10.7-24 24s10.7 24 24 24l80 0c13.3 0 24-10.7 24-24s-10.7-24-24-24l-8 0 0-88c0-13.3-10.7-24-24-24l-48 0c-13.3 0-24 10.7-24 24s10.7 24 24 24l24 0 0 64-24 0zm40-144a32 32 0 1 0 0-64 32 32 0 1 0 0 64z"/></svg>
+                        </button></div>
+                        <div id="oddsInfoPopup" class="info-popup">When unchecked, low or medium odds items from season 0 and CTW are skipped. Normal odds items are always included.</div>
                         <div class="warlord-toggle"><input type="checkbox" id="includeLowOdds"><label for="includeLowOdds">Include low odds items</label></div>
                         <div class="warlord-toggle"><input type="checkbox" id="includeMediumOdds"><label for="includeMediumOdds">Include medium odds items</label></div>
                         <p id="toggleAdvMaterials" class="adv-toggle">Also use gear materials

--- a/style.css
+++ b/style.css
@@ -63,6 +63,59 @@ body {
     font-size: 13px;
 }
 
+.section-title {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-top: 20px;
+    color: var(--primary-color);
+    font-weight: bold;
+}
+
+.section-title span {
+    position: relative;
+    padding: 0 10px;
+}
+
+.section-title span:before,
+.section-title span:after {
+    content: '';
+    flex: 1;
+    border-bottom: 1px solid var(--primary-color);
+}
+
+.section-title span:before {
+    margin-right: 10px;
+}
+
+.section-title span:after {
+    margin-left: 10px;
+}
+
+.info-btn {
+    background: none;
+    border: none;
+    padding: 0;
+    margin-left: 5px;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    fill: var(--primary-color);
+    width: 16px;
+    height: 16px;
+}
+
+.info-popup {
+    display: none;
+    margin-top: 5px;
+    padding: 10px;
+    background: #fff;
+    border: 1px solid var(--primary-color);
+    border-radius: 4px;
+    box-shadow: 0px 4px 8px 0px var(--shadow-color);
+    font-size: 14px;
+}
+
 .wrapper {
     max-width: 600px;
     margin: 20px auto;


### PR DESCRIPTION
## Summary
- add Ceremonial Targ and odds headers with info buttons
- style section titles and info popups
- add JS for toggling CTW and odds popups

## Testing
- `node --check craftparse.js`


------
https://chatgpt.com/codex/tasks/task_b_684bae9760508322a859e9e677dd54d9