### PR TITLE
Improve CTW and odds UI

### DIFF
--- a/craftparse.js
+++ b/craftparse.js
@@ -69,7 +69,12 @@ document.addEventListener('DOMContentLoaded', function() {
     const ctwPopup = document.getElementById('ctwInfoPopup');
     ctwBtn?.addEventListener('click', () => {
         if (ctwPopup) {
-            ctwPopup.style.display = ctwPopup.style.display === 'block' ? 'none' : 'block';
+            ctwPopup.style.display = 'flex';
+        }
+    });
+    ctwPopup?.addEventListener('click', (e) => {
+        if (e.target === ctwPopup || e.target.classList.contains('close-popup')) {
+            ctwPopup.style.display = 'none';
         }
     });
 
@@ -77,7 +82,12 @@ document.addEventListener('DOMContentLoaded', function() {
     const oddsPopup = document.getElementById('oddsInfoPopup');
     oddsBtn?.addEventListener('click', () => {
         if (oddsPopup) {
-            oddsPopup.style.display = oddsPopup.style.display === 'block' ? 'none' : 'block';
+            oddsPopup.style.display = 'flex';
+        }
+    });
+    oddsPopup?.addEventListener('click', (e) => {
+        if (e.target === oddsPopup || e.target.classList.contains('close-popup')) {
+            oddsPopup.style.display = 'none';
         }
     });
 });

--- a/index.html
+++ b/index.html
@@ -146,16 +146,16 @@
 				</select>
 			</div>
 			
-                        <div class="section-title"><span>Use Ceremonial Targ items</span><button id="ctwInfoBtn" class="info-btn" aria-label="CTW info">
+                        <div class="section-title"><span>Ceremonial Targ items</span><button id="ctwInfoBtn" class="info-btn" aria-label="CTW info">
                                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336c-13.3 0-24 10.7-24 24s10.7 24 24 24l80 0c13.3 0 24-10.7 24-24s-10.7-24-24-24l-8 0 0-88c0-13.3-10.7-24-24-24l-48 0c-13.3 0-24 10.7-24 24s10.7 24 24 24l24 0 0 64-24 0zm40-144a32 32 0 1 0 0-64 32 32 0 1 0 0 64z"/></svg>
                         </button></div>
-                        <div id="ctwInfoPopup" class="info-popup">Ceremonial Targ items are special items from CTW events. "Include in calculations" lets the planner pick them for any level. "Only use for level 1" restricts level 1 to these items, but other levels may still use them.</div>
-                        <div class="warlord-toggle"><input type="checkbox" id="includeWarlords"><label for="includeWarlords">Include in calculations</label></div>
-                        <div class="warlord-toggle"><input type="checkbox" id="level1OnlyWarlords" checked><label for="level1OnlyWarlords">Only use for level 1</label></div>
+                        <div id="ctwInfoPopup" class="info-overlay"><div class="info-content"><button class="close-popup" aria-label="Close">&times;</button><p>Ceremonial Targ items are special items from CTW events. "Allow at all levels" lets the planner pick them for any level. "Limit to level 1" restricts them to level 1 only.</p></div></div>
+                        <div class="warlord-toggle"><input type="checkbox" id="includeWarlords"><label for="includeWarlords">Allow at all levels</label></div>
+                        <div class="warlord-toggle"><input type="checkbox" id="level1OnlyWarlords" checked><label for="level1OnlyWarlords">Limit to level 1</label></div>
                         <div class="section-title"><span>Odds</span><button id="oddsInfoBtn" class="info-btn" aria-label="Odds info">
                                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336c-13.3 0-24 10.7-24 24s10.7 24 24 24l80 0c13.3 0 24-10.7 24-24s-10.7-24-24-24l-8 0 0-88c0-13.3-10.7-24-24-24l-48 0c-13.3 0-24 10.7-24 24s10.7 24 24 24l24 0 0 64-24 0zm40-144a32 32 0 1 0 0-64 32 32 0 1 0 0 64z"/></svg>
                         </button></div>
-                        <div id="oddsInfoPopup" class="info-popup">When unchecked, low or medium odds items from season 0 and CTW are skipped. Normal odds items are always included.</div>
+                        <div id="oddsInfoPopup" class="info-overlay"><div class="info-content"><button class="close-popup" aria-label="Close">&times;</button><p>When unchecked, low or medium odds items from season 0 and CTW are skipped. Normal odds items are always included.</p></div></div>
                         <div class="warlord-toggle"><input type="checkbox" id="includeLowOdds"><label for="includeLowOdds">Include low odds items</label></div>
                         <div class="warlord-toggle"><input type="checkbox" id="includeMediumOdds"><label for="includeMediumOdds">Include medium odds items</label></div>
                         <p id="toggleAdvMaterials" class="adv-toggle">Also use gear materials

--- a/style.css
+++ b/style.css
@@ -43,16 +43,49 @@ body {
     width: 110px;
 }
 
-.warlord-toggle label {
-    top: 1px;
-    left: 25px;
-    padding: 0;
-    user-select: none;
-}
-
 .warlord-toggle {
     position: relative;
     margin-top: 10px;
+}
+
+.warlord-toggle input[type="checkbox"] {
+    position: absolute;
+    opacity: 0;
+    left: 0;
+    top: 0;
+    width: 20px;
+    height: 20px;
+    margin: 0;
+}
+
+.warlord-toggle label {
+    position: relative;
+    padding-left: 28px;
+    cursor: pointer;
+    user-select: none;
+}
+
+.warlord-toggle label:before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 18px;
+    height: 18px;
+    border: 1px solid var(--primary-color);
+    border-radius: 3px;
+    background: #fff;
+}
+
+.warlord-toggle input[type="checkbox"]:checked + label:after {
+    content: '';
+    position: absolute;
+    left: 4px;
+    top: 4px;
+    width: 10px;
+    height: 10px;
+    background: var(--primary-color);
+    border-radius: 2px;
 }
 .warlord-toggle ~ p.odds-info {
     margin-bottom: -5px;
@@ -105,15 +138,36 @@ body {
     height: 16px;
 }
 
-.info-popup {
+.info-overlay {
     display: none;
-    margin-top: 5px;
-    padding: 10px;
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.5);
+    align-items: center;
+    justify-content: center;
+    z-index: 10;
+}
+
+.info-overlay .info-content {
     background: #fff;
     border: 1px solid var(--primary-color);
     border-radius: 4px;
     box-shadow: 0px 4px 8px 0px var(--shadow-color);
+    padding: 20px;
+    max-width: 400px;
+    position: relative;
     font-size: 14px;
+}
+
+.info-overlay .close-popup {
+    position: absolute;
+    top: 5px;
+    right: 5px;
+    background: none;
+    border: none;
+    font-size: 20px;
+    color: var(--primary-color);
+    cursor: pointer;
 }
 
 .wrapper {


### PR DESCRIPTION
## Summary
- restyle toggles with custom checkboxes
- show info buttons as modal overlays with closing X
- tweak Ceremonial Targ section text

## Testing
- `node -e "require('./craftparse.js')"` *(fails: ReferenceError: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_b_684bb5ab936c83229ebbaef3c521b1ab