### PR TITLE
Fix CTW card set names

### DIFF
--- a/products.js
+++ b/products.js
@@ -1,33 +1,33 @@
 let craftItem = {
 	products: [
-		...season0.sets.flatMap(set =>
-			set.products.map(product => ({
-				...product,
-				setName: set.setName,
-				season: season0.season
-			}))
-		),
-		...season10.sets.flatMap(set =>
-			set.products.map(product => ({
-				...product,
-				setName: set.setName,
-				season: season10.season
-			}))
-		),
-		...season11.sets.flatMap(set =>
-			set.products.map(product => ({
-				...product,
-				setName: set.setName,
-				season: season11.season
-			}))
-		),
-		...season12.sets.flatMap(set =>
-			set.products.map(product => ({
-				...product,
-				setName: set.setName,
-				season: season12.season
-			}))
-		)
+                ...season0.sets.flatMap(set =>
+                        set.products.map(product => ({
+                                ...product,
+                                setName: product.setName || set.setName,
+                                season: season0.season
+                        }))
+                ),
+                ...season10.sets.flatMap(set =>
+                        set.products.map(product => ({
+                                ...product,
+                                setName: product.setName || set.setName,
+                                season: season10.season
+                        }))
+                ),
+                ...season11.sets.flatMap(set =>
+                        set.products.map(product => ({
+                                ...product,
+                                setName: product.setName || set.setName,
+                                season: season11.season
+                        }))
+                ),
+                ...season12.sets.flatMap(set =>
+                        set.products.map(product => ({
+                                ...product,
+                                setName: product.setName || set.setName,
+                                season: season12.season
+                        }))
+                )
 	]
 };
 


### PR DESCRIPTION
## Summary
- preserve per-product set names when building product list

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_684c8ac9eef88322be001758bcf1376d