### PR TITLE
Add gear material usage info section

### DIFF
--- a/craftparse.js
+++ b/craftparse.js
@@ -92,6 +92,19 @@ document.addEventListener('DOMContentLoaded', function() {
             oddsPopup.style.display = 'none';
         }
     });
+
+    const gearBtn = document.getElementById('gearLevelsInfoBtn');
+    const gearPopup = document.getElementById('gearLevelsInfoPopup');
+    gearBtn?.addEventListener('click', () => {
+        if (gearPopup) {
+            gearPopup.style.display = 'flex';
+        }
+    });
+    gearPopup?.addEventListener('click', (e) => {
+        if (e.target === gearPopup || e.target.closest('.close-popup')) {
+            gearPopup.style.display = 'none';
+        }
+    });
 });
 
 function formatPlaceholderWithCommas(number) {
@@ -1143,11 +1156,30 @@ function initAdvMaterialSection() {
         });
     });
 
+    const infoHeader = document.createElement('div');
+    infoHeader.className = 'section-title';
+    const infoInner = document.createElement('div');
+    infoInner.className = 'checkbox-header';
+    const infoSpan = document.createElement('span');
+    infoSpan.textContent = 'Gear materials at levels';
+    const infoBtn = document.createElement('button');
+    infoBtn.id = 'gearLevelsInfoBtn';
+    infoBtn.className = 'info-btn';
+    infoBtn.setAttribute('aria-label', 'Gear materials info');
+    infoBtn.innerHTML = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336c-13.3 0-24 10.7-24 24s10.7 24 24 24l80 0c13.3 0 24-10.7 24-24s-10.7-24-24-24l-8 0 0-88c0-13.3-10.7-24-24-24l-48 0c-13.3 0-24 10.7-24 24s10.7 24 24 24l24 0 0 64-24 0zm40-144a32 32 0 1 0 0-64 32 32 0 1 0 0 64z"/></svg>';
+    infoInner.appendChild(infoSpan);
+    infoInner.appendChild(infoBtn);
+    infoHeader.appendChild(infoInner);
+    container.appendChild(infoHeader);
+
+    const infoPopup = document.createElement('div');
+    infoPopup.id = 'gearLevelsInfoPopup';
+    infoPopup.className = 'info-overlay';
+    infoPopup.innerHTML = '<div class="info-content"><button class="close-popup" aria-label="Close"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><path d="M345 137c9.4-9.4 9.4-24.6 0-33.9s-24.6-9.4-33.9 0l-119 119L73 103c-9.4-9.4-24.6-9.4-33.9 0s-9.4 24.6 0 33.9l119 119L39 375c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l119-119L311 409c9.4 9.4 24.6 9.4 33.9 0s9.4-24.6 0-33.9l-119-119L345 137z"></path></svg></button><p>Select the levels where gear set materials may be used. Other levels craft only with basic materials so you can save sets for later.</p></div>';
+    container.appendChild(infoPopup);
+
     const levelWrap = document.createElement('div');
     levelWrap.className = 'level-select-container';
-    const levelLabel = document.createElement('p');
-    levelLabel.textContent = 'Allow gear material usage at levels';
-    levelWrap.appendChild(levelLabel);
 
     const dropdown = document.createElement('div');
     dropdown.className = 'level-dropdown';

--- a/style.css
+++ b/style.css
@@ -532,7 +532,7 @@ button.multiplier-btn {
 	cursor: pointer;
 	color: var(--primary-color);
 	font-weight: bold;
-	display: inline-flex;
+	display: flex;
 	align-items: center;
 	width: 100%;
 	font-size: 16px;


### PR DESCRIPTION
## Summary
- add info section for gear material levels
- handle info dialog open/close in script
- shorten header text and clarify popup message

## Testing
- `node --check craftparse.js`
- `node --check products.js`


------
https://chatgpt.com/codex/tasks/task_b_684f95aaee408322a55139e489449ebe