### PR TITLE
Add scale setting for materials

### DIFF
--- a/craftparse.js
+++ b/craftparse.js
@@ -105,6 +105,19 @@ document.addEventListener('DOMContentLoaded', function() {
             gearPopup.style.display = 'none';
         }
     });
+
+    const scaleBtn = document.getElementById('scaleInfoBtn');
+    const scalePopup = document.getElementById('scaleInfoPopup');
+    scaleBtn?.addEventListener('click', () => {
+        if (scalePopup) {
+            scalePopup.style.display = 'flex';
+        }
+    });
+    scalePopup?.addEventListener('click', (e) => {
+        if (e.target === scalePopup || e.target.closest('.close-popup')) {
+            scalePopup.style.display = 'none';
+        }
+    });
 });
 
 function formatPlaceholderWithCommas(number) {
@@ -112,21 +125,21 @@ function formatPlaceholderWithCommas(number) {
 }
 
 function formatedInputNumber(){
-	document.addEventListener('input', function(e) {
-		if (e.target.classList.contains('numeric-input')) {
-			let inputValue = e.target.value;
+        document.addEventListener('input', function(e) {
+            if (e.target.classList.contains('numeric-input')) {
+                let inputValue = e.target.value;
 
-			// Poista kaikki muut merkit paitsi numerot ja pilkut
-			let numericValue = inputValue.replace(/[^0-9,]/g, '');
+                // Salli numerot, pilkut ja pisteet desimaaleille
+                let numericValue = inputValue.replace(/[^0-9.,]/g, '');
 
-			// Muunna numero USA-formaattiin
-			let formattedValue = numericValue
-				.replace(/,/g, '') // Poista ensin olemassa olevat pilkut, jotta ne eivät häiritse
-				.replace(/\B(?=(\d{3})+(?!\d))/g, ","); // Lisää pilkut joka kolmannen numeron jälkeen
+                // Erottele desimaaliosa, jos sellainen on
+                let parts = numericValue.split('.');
+                let integerPart = parts[0].replace(/,/g, '');
+                integerPart = integerPart.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
 
-			e.target.value = formattedValue;
-		}
-	});
+                e.target.value = parts.length > 1 ? `${integerPart}.${parts[1]}` : integerPart;
+            }
+        });
 
 }
 
@@ -705,16 +718,19 @@ document.getElementById('calculateWithPreferences').addEventListener('click', fu
 });
 
 function gatherMaterialsFromInputs() {
+    const scaleSelect = document.getElementById('scaleSelect');
+    const scale = scaleSelect ? parseFloat(scaleSelect.value) || 1 : 1;
     let materialsInput = {};
     document.querySelectorAll('.my-material input[type="text"]').forEach(input => {
         const id = input.getAttribute('id').replace('my-', '');
         const materialName = Object.keys(allMaterials).find(name => name.toLowerCase().replace(/\s/g, '-') === id);
-        const materialAmount = parseInt(input.value.replace(/,/g, ''), 10);
+        const raw = input.value.replace(/,/g, '');
+        const materialAmount = parseFloat(raw);
         if (!materialName) {
             return;
         }
         if (!isNaN(materialAmount)) {
-            materialsInput[materialName] = materialAmount;
+            materialsInput[materialName] = materialAmount * scale;
         }
     });
 

--- a/index.html
+++ b/index.html
@@ -41,9 +41,18 @@
 					<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><!--!Font Awesome Free 6.6.0 by @fontawesome - https://fontawesome.com License - https://fontawesome.com/license/free Copyright 2024 Fonticons, Inc.--><path d="M190.5 68.8L225.3 128l-1.3 0-72 0c-22.1 0-40-17.9-40-40s17.9-40 40-40l2.2 0c14.9 0 28.8 7.9 36.3 20.8zM64 88c0 14.4 3.5 28 9.6 40L32 128c-17.7 0-32 14.3-32 32l0 64c0 17.7 14.3 32 32 32l448 0c17.7 0 32-14.3 32-32l0-64c0-17.7-14.3-32-32-32l-41.6 0c6.1-12 9.6-25.6 9.6-40c0-48.6-39.4-88-88-88l-2.2 0c-31.9 0-61.5 16.9-77.7 44.4L256 85.5l-24.1-41C215.7 16.9 186.1 0 154.2 0L152 0C103.4 0 64 39.4 64 88zm336 0c0 22.1-17.9 40-40 40l-72 0-1.3 0 34.8-59.2C329.1 55.9 342.9 48 357.8 48l2.2 0c22.1 0 40 17.9 40 40zM32 288l0 176c0 26.5 21.5 48 48 48l144 0 0-224L32 288zM288 512l144 0c26.5 0 48-21.5 48-48l0-176-192 0 0 224z"/></svg>
 				</button>
 			</div>
-			<div id="yourMaterials" class="material-choices">
-				<h4>Your materials:</h4>
-				<div class="materials-list">
+                        <div class="section-title"><div class="checkbox-header"><span>Scale</span><button id="scaleInfoBtn" class="info-btn" aria-label="Scale info">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336c-13.3 0-24 10.7-24 24s10.7 24 24 24l80 0c13.3 0 24-10.7 24-24s-10.7-24-24-24l-8 0 0-88c0-13.3-10.7-24-24-24l-48 0c-13.3 0-24 10.7-24 24s10.7 24 24 24l24 0 0 64-24 0zm40-144a32 32 0 1 0 0-64 32 32 0 1 0 0 64z"/></svg>
+                                </button></div></div>
+                        <div id="scaleInfoPopup" class="info-overlay"><div class="info-content"><button class="close-popup" aria-label="Close"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><path d="M345 137c9.4-9.4 9.4-24.6 0-33.9s-24.6-9.4-33.9 0l-119 119L73 103c-9.4-9.4-24.6-9.4-33.9 0s-9.4 24.6 0 33.9l119 119L39 375c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l119-119L311 409c9.4 9.4 24.6 9.4 33.9 0s9.4-24.6 0-33.9l-119-119L345 137z"/></svg></button><p>Select how material amounts are scaled. "1 - 1,000,000" multiplies your input by one million. Results always show actual amounts.</p></div></div>
+                        <select id="scaleSelect" class="temps">
+                                <option value="1">Normal (1:1)</option>
+                                <option value="1000000">1 - 1,000,000</option>
+                        </select>
+
+                        <div id="yourMaterials" class="material-choices">
+                                <div class="section-title"><div class="checkbox-header"><span>Your materials</span></div></div>
+                                <div class="materials-list">
 					<div class="my-material black-iron"><img src="materials/icon_crafting_blackiron.webp"><div><span>Black Iron</span><input type="text" class="numeric-input" id="my-black-iron" name="my-black-iron" placeholder="value" pattern="[0-9]*" inputmode="numeric"></div></div>
 					<div class="my-material copper-bar"><img src="materials/icon_crafting_copper_bar.webp"><div><span>Copper bar</span><input type="text" class="numeric-input" id="my-copper-bar" name="my-copper-bar" placeholder="value" pattern="[0-9]*" inputmode="numeric"></div></div>
 					<div class="my-material dragonglass"><img src="materials/icon_crafting_dragonglass.webp"><div><span>Dragonglass</span><input type="text" class="numeric-input" id="my-dragonglass" name="my-dragonglass" placeholder="value" pattern="[0-9]*" inputmode="numeric"></div></div>


### PR DESCRIPTION
## Summary
- add scale selection before materials with an info popup
- unify materials header styling
- support decimal inputs and scale values in material gathering

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_685000e5a3f483229d115bffbe9fce51