### PR TITLE
Fix template count state when loaded via share link

### DIFF
--- a/craftparse.js
+++ b/craftparse.js
@@ -220,7 +220,11 @@ function populateInputsFromShare(data) {
             });
             if (total > 0) {
                 const amountInput = document.getElementById(`templateAmount${level}`);
-                if (amountInput) amountInput.value = total;
+                if (amountInput) {
+                    amountInput.value = total;
+                    const wrap = document.querySelector(`.leveltmp${level} .templateAmountWrap`);
+                    if (wrap) wrap.classList.add('active');
+                }
             }
             if (quality) {
                 const sel = document.getElementById(`temp${level}`);
@@ -247,6 +251,11 @@ function populateInputsFromShare(data) {
                 if (divOpt) divOpt.classList.toggle('selected', isSel);
             });
         }
+    }
+    if (history.replaceState) {
+        const url = new URL(window.location);
+        url.searchParams.delete('share');
+        history.replaceState({}, '', url.pathname + url.search);
     }
 }
 

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
 	<link rel="icon" type="image/png" href="favicon.png">
     <link rel="stylesheet" href="style.css?v=1.115">
 	<script src="seasons/season0.js"></script>
+	<script src="seasons/season8.js"></script>
 	<script src="seasons/season9.js"></script>
 	<script src="seasons/season10.js"></script>
 	<script src="seasons/season11.js"></script>

--- a/products.js
+++ b/products.js
@@ -7,6 +7,13 @@ let craftItem = {
 						season: season0.season
 				}))
 		),
+		...season8.sets.flatMap(set =>
+				set.products.map(product => ({
+						...product,
+						setName: product.setName || set.setName,
+						season: season8.season
+				}))
+		),
 		...season9.sets.flatMap(set =>
 				set.products.map(product => ({
 						...product,
@@ -38,4 +45,4 @@ let craftItem = {
 	]
 };
 
-window.seasons = [season0, season9, season10, season11, season12];
+window.seasons = [season0, season8, season9, season10, season11, season12];

--- a/seasons/season8.js
+++ b/seasons/season8.js
@@ -1,0 +1,641 @@
+const season8 = {
+	season: 8,
+	sets: [
+		{
+		  "setName": "Living Mountain's",
+		  "setMat": "Dark Steel Plate",
+		  "products": [
+			{
+			  "name": "Great Helm",
+			  "level": 5,
+			  "materials": {
+				"dark-steel-plate": 10,
+				"kingswood-oak": 10,
+				"hide": 10
+			  },
+			  "img": "item/season8/living-mountain/head.png"
+			},
+			{
+			  "name": "Dark Steel Field Plate",
+			  "level": 5,
+			  "materials": {
+				"dark-steel-plate": 10,
+				"leather-straps": 10,
+				"black-iron": 10
+			  },
+			  "img": "item/season8/living-mountain/chest.png"
+			},
+			{
+			  "name": "Plated Faulds",
+			  "level": 5,
+			  "materials": {
+				"dark-steel-plate": 10,
+				"dragonglass": 10,
+				"silk": 10
+			  },
+			  "img": "item/season8/living-mountain/pants.png"
+			},
+			{
+			  "name": "Riding Boots",
+			  "level": 5,
+			  "materials": {
+				"dark-steel-plate": 10,
+				"silk": 10,
+				"weirwood": 10
+			  },
+			  "img": "item/season8/living-mountain/boots.png"
+			},
+			{
+			  "name": "Dark Steel Ring",
+			  "level": 5,
+			  "materials": {
+				"dark-steel-plate": 10,
+				"goldenheart-wood": 10,
+				"milk-of-the-poppy": 10
+			  },
+			  "img": "item/season8/living-mountain/ring.png"
+			},
+			{
+			  "name": "Cruel Claymore",
+			  "level": 5,
+			  "materials": {
+				"dark-steel-plate": 10,
+				"ironwood": 10,
+				"wildfire": 10
+			  },
+			  "img": "item/season8/living-mountain/weapon.png"
+			},
+			{
+			  "name": "Great Helm",
+			  "level": 10,
+			  "materials": {
+				"dark-steel-plate": 20,
+				"kingswood-oak": 20,
+				"hide": 20
+			  },
+			  "img": "item/season8/living-mountain/head.png"
+			},
+			{
+			  "name": "Dark Steel Field Plate",
+			  "level": 10,
+			  "materials": {
+				"dark-steel-plate": 20,
+				"leather-straps": 20,
+				"black-iron": 20
+			  },
+			  "img": "item/season8/living-mountain/chest.png"
+			},
+			{
+			  "name": "Plated Faulds",
+			  "level": 10,
+			  "materials": {
+				"dark-steel-plate": 20,
+				"dragonglass": 20,
+				"silk": 20
+			  },
+			  "img": "item/season8/living-mountain/pants.png"
+			},
+			{
+			  "name": "Riding Boots",
+			  "level": 10,
+			  "materials": {
+				"dark-steel-plate": 20,
+				"silk": 20,
+				"weirwood": 20
+			  },
+			  "img": "item/season8/living-mountain/boots.png"
+			},
+			{
+			  "name": "Dark Steel Ring",
+			  "level": 10,
+			  "materials": {
+				"dark-steel-plate": 20,
+				"goldenheart-wood": 20,
+				"milk-of-the-poppy": 20
+			  },
+			  "img": "item/season8/living-mountain/ring.png"
+			},
+			{
+			  "name": "Cruel Claymore",
+			  "level": 10,
+			  "materials": {
+				"dark-steel-plate": 20,
+				"ironwood": 20,
+				"wildfire": 20
+			  },
+			  "img": "item/season8/living-mountain/weapon.png"
+			},
+			{
+			  "name": "Great Helm",
+			  "level": 15,
+			  "materials": {
+				"dark-steel-plate": 120,
+				"kingswood-oak": 120,
+				"hide": 120
+			  },
+			  "img": "item/season8/living-mountain/head.png"
+			},
+			{
+			  "name": "Dark Steel Field Plate",
+			  "level": 15,
+			  "materials": {
+				"dark-steel-plate": 120,
+				"leather-straps": 120,
+				"black-iron": 120
+			  },
+			  "img": "item/season8/living-mountain/chest.png"
+			},
+			{
+			  "name": "Plated Faulds",
+			  "level": 15,
+			  "materials": {
+				"dark-steel-plate": 120,
+				"dragonglass": 120,
+				"silk": 120
+			  },
+			  "img": "item/season8/living-mountain/pants.png"
+			},
+			{
+			  "name": "Riding Boots",
+			  "level": 15,
+			  "materials": {
+				"dark-steel-plate": 120,
+				"silk": 120,
+				"weirwood": 120
+			  },
+			  "img": "item/season8/living-mountain/boots.png"
+			},
+			{
+			  "name": "Dark Steel Ring",
+			  "level": 15,
+			  "materials": {
+				"dark-steel-plate": 120,
+				"goldenheart-wood": 120,
+				"milk-of-the-poppy": 120
+			  },
+			  "img": "item/season8/living-mountain/ring.png"
+			},
+			{
+			  "name": "Cruel Claymore",
+			  "level": 15,
+			  "materials": {
+				"dark-steel-plate": 120,
+				"ironwood": 120,
+				"wildfire": 120
+			  },
+			  "img": "item/season8/living-mountain/weapon.png"
+			},
+			{
+			  "name": "Great Helm",
+			  "level": 20,
+			  "materials": {
+				"dark-steel-plate": 400,
+				"kingswood-oak": 400,
+				"hide": 400,
+				"copper-bar": 400
+			  },
+			  "img": "item/season8/living-mountain/head.png"
+			},
+			{
+			  "name": "Dark Steel Field Plate",
+			  "level": 20,
+			  "materials": {
+				"dark-steel-plate": 400,
+				"leather-straps": 400,
+				"black-iron": 400,
+				"goldenheart-wood": 400
+			  },
+			  "img": "item/season8/living-mountain/chest.png"
+			},
+			{
+			  "name": "Plated Faulds",
+			  "level": 20,
+			  "materials": {
+				"dark-steel-plate": 400,
+				"dragonglass": 400,
+				"silk": 400,
+				"black-iron": 400
+			  },
+			  "img": "item/season8/living-mountain/pants.png"
+			},
+			{
+			  "name": "Riding Boots",
+			  "level": 20,
+			  "materials": {
+				"dark-steel-plate": 400,
+				"silk": 400,
+				"weirwood": 400,
+				"ironwood": 400
+			  },
+			  "img": "item/season8/living-mountain/boots.png"
+			},
+			{
+			  "name": "Dark Steel Ring",
+			  "level": 20,
+			  "materials": {
+				"dark-steel-plate": 400,
+				"goldenheart-wood": 400,
+				"milk-of-the-poppy": 400,
+				"weirwood": 400
+			  },
+			  "img": "item/season8/living-mountain/ring.png"
+			},
+			{
+			  "name": "Cruel Claymore",
+			  "level": 20,
+			  "materials": {
+				"dark-steel-plate": 400,
+				"ironwood": 400,
+				"wildfire": 400,
+				"leather-straps": 400
+			  },
+			  "img": "item/season8/living-mountain/weapon.png"
+			},
+			{
+			  "name": "Great Helm",
+			  "level": 25,
+			  "materials": {
+				"dark-steel-plate": 1200,
+				"kingswood-oak": 1200,
+				"hide": 1200,
+				"copper-bar": 1200
+			  },
+			  "img": "item/season8/living-mountain/head.png"
+			},
+			{
+			  "name": "Dark Steel Field Plate",
+			  "level": 25,
+			  "materials": {
+				"dark-steel-plate": 1200,
+				"leather-straps": 1200,
+				"black-iron": 1200,
+				"goldenheart-wood": 1200
+			  },
+			  "img": "item/season8/living-mountain/chest.png"
+			},
+			{
+			  "name": "Plated Faulds",
+			  "level": 25,
+			  "materials": {
+				"dark-steel-plate": 1200,
+				"dragonglass": 1200,
+				"silk": 1200,
+				"black-iron": 1200
+			  },
+			  "img": "item/season8/living-mountain/pants.png"
+			},
+			{
+			  "name": "Riding Boots",
+			  "level": 25,
+			  "materials": {
+				"dark-steel-plate": 1200,
+				"silk": 1200,
+				"weirwood": 1200,
+				"ironwood": 1200
+			  },
+			  "img": "item/season8/living-mountain/boots.png"
+			},
+			{
+			  "name": "Dark Steel Ring",
+			  "level": 25,
+			  "materials": {
+				"dark-steel-plate": 1200,
+				"goldenheart-wood": 1200,
+				"milk-of-the-poppy": 1200,
+				"weirwood": 1200
+			  },
+			  "img": "item/season8/living-mountain/ring.png"
+			},
+			{
+			  "name": "Cruel Claymore",
+			  "level": 25,
+			  "materials": {
+				"dark-steel-plate": 1200,
+				"ironwood": 1200,
+				"wildfire": 1200,
+				"leather-straps": 1200
+			  },
+			  "img": "item/season8/living-mountain/weapon.png"
+			}
+		  ]
+		},
+		{
+		  "setName": "Dragon Rider's",
+		  "setMat": "Dragon Tempered Fabrics",
+		  "products": [
+			{
+			  "name": "Jeweled Adornment",
+			  "level": 5,
+			  "materials": {
+				"dragon-tempered": 10,
+				"wildfire": 10,
+				"dragonglass": 10
+			  },
+			  "img": "item/season8/dragon-rider/head.png"
+			},
+			{
+			  "name": "Jacket",
+			  "level": 5,
+			  "materials": {
+				"dragon-tempered": 10,
+				"kingswood-oak": 10,
+				"copper-bar": 10
+			  },
+			  "img": "item/season8/dragon-rider/chest.png"
+			},
+			{
+			  "name": "Bases",
+			  "level": 5,
+			  "materials": {
+				"dragon-tempered": 10,
+				"ironwood": 10,
+				"wildfire": 10
+			  },
+			  "img": "item/season8/dragon-rider/pants.png"
+			},
+			{
+			  "name": "Heeled Boots",
+			  "level": 5,
+			  "materials": {
+				"dragon-tempered": 10,
+				"milk-of-the-poppy": 10,
+				"kingswood-oak": 10
+			  },
+			  "img": "item/season8/dragon-rider/boots.png"
+			},
+			{
+			  "name": "Encrusted Ring",
+			  "level": 5,
+			  "materials": {
+				"dragon-tempered": 10,
+				"weirwood": 10,
+				"black-iron": 10
+			  },
+			  "img": "item/season8/dragon-rider/ring.png"
+			},
+			{
+			  "name": "Keen Spears",
+			  "level": 5,
+			  "materials": {
+				"dragon-tempered": 10,
+				"hide": 10,
+				"goldenheart-wood": 10
+			  },
+			  "img": "item/season8/dragon-rider/weapon.png"
+			},
+			{
+			  "name": "Jeweled Adornment",
+			  "level": 10,
+			  "materials": {
+				"dragon-tempered": 20,
+				"wildfire": 20,
+				"dragonglass": 20
+			  },
+			  "img": "item/season8/dragon-rider/head.png"
+			},
+			{
+			  "name": "Jacket",
+			  "level": 10,
+			  "materials": {
+				"dragon-tempered": 20,
+				"kingswood-oak": 20,
+				"copper-bar": 20
+			  },
+			  "img": "item/season8/dragon-rider/chest.png"
+			},
+			{
+			  "name": "Bases",
+			  "level": 10,
+			  "materials": {
+				"dragon-tempered": 20,
+				"ironwood": 20,
+				"wildfire": 20
+			  },
+			  "img": "item/season8/dragon-rider/pants.png"
+			},
+			{
+			  "name": "Heeled Boots",
+			  "level": 10,
+			  "materials": {
+				"dragon-tempered": 20,
+				"milk-of-the-poppy": 20,
+				"kingswood-oak": 20
+			  },
+			  "img": "item/season8/dragon-rider/boots.png"
+			},
+			{
+			  "name": "Encrusted Ring",
+			  "level": 10,
+			  "materials": {
+				"dragon-tempered": 20,
+				"weirwood": 20,
+				"black-iron": 20
+			  },
+			  "img": "item/season8/dragon-rider/ring.png"
+			},
+			{
+			  "name": "Keen Spears",
+			  "level": 10,
+			  "materials": {
+				"dragon-tempered": 20,
+				"hide": 20,
+				"goldenheart-wood": 20
+			  },
+			  "img": "item/season8/dragon-rider/weapon.png"
+			},
+			{
+			  "name": "Jeweled Adornment",
+			  "level": 15,
+			  "materials": {
+				"dragon-tempered": 120,
+				"wildfire": 120,
+				"dragonglass": 120
+			  },
+			  "img": "item/season8/dragon-rider/head.png"
+			},
+			{
+			  "name": "Jacket",
+			  "level": 15,
+			  "materials": {
+				"dragon-tempered": 120,
+				"kingswood-oak": 120,
+				"copper-bar": 120
+			  },
+			  "img": "item/season8/dragon-rider/chest.png"
+			},
+			{
+			  "name": "Bases",
+			  "level": 15,
+			  "materials": {
+				"dragon-tempered": 120,
+				"ironwood": 120,
+				"wildfire": 120
+			  },
+			  "img": "item/season8/dragon-rider/pants.png"
+			},
+			{
+			  "name": "Heeled Boots",
+			  "level": 15,
+			  "materials": {
+				"dragon-tempered": 120,
+				"milk-of-the-poppy": 120,
+				"kingswood-oak": 120
+			  },
+			  "img": "item/season8/dragon-rider/boots.png"
+			},
+			{
+			  "name": "Encrusted Ring",
+			  "level": 15,
+			  "materials": {
+				"dragon-tempered": 120,
+				"weirwood": 120,
+				"black-iron": 120
+			  },
+			  "img": "item/season8/dragon-rider/ring.png"
+			},
+			{
+			  "name": "Keen Spears",
+			  "level": 15,
+			  "materials": {
+				"dragon-tempered": 120,
+				"hide": 120,
+				"goldenheart-wood": 120
+			  },
+			  "img": "item/season8/dragon-rider/weapon.png"
+			},
+			{
+			  "name": "Jeweled Adornment",
+			  "level": 20,
+			  "materials": {
+				"dragon-tempered": 400,
+				"wildfire": 400,
+				"dragonglass": 400,
+				"milk-of-the-poppy": 400
+			  },
+			  "img": "item/season8/dragon-rider/head.png"
+			},
+			{
+			  "name": "Jacket",
+			  "level": 20,
+			  "materials": {
+				"dragon-tempered": 400,
+				"kingswood-oak": 400,
+				"copper-bar": 400,
+				"goldenheart-wood": 400
+			  },
+			  "img": "item/season8/dragon-rider/chest.png"
+			},
+			{
+			  "name": "Bases",
+			  "level": 20,
+			  "materials": {
+				"dragon-tempered": 400,
+				"ironwood": 400,
+				"wildfire": 400,
+				"copper-bar": 400
+			  },
+			  "img": "item/season8/dragon-rider/pants.png"
+			},
+			{
+			  "name": "Heeled Boots",
+			  "level": 20,
+			  "materials": {
+				"dragon-tempered": 400,
+				"milk-of-the-poppy": 400,
+				"kingswood-oak": 400,
+				"ironwood": 400
+			  },
+			  "img": "item/season8/dragon-rider/boots.png"
+			},
+			{
+			  "name": "Encrusted Ring",
+			  "level": 20,
+			  "materials": {
+				"dragon-tempered": 400,
+				"weirwood": 400,
+				"black-iron": 400,
+				"silk": 400
+			  },
+			  "img": "item/season8/dragon-rider/ring.png"
+			},
+			{
+			  "name": "Keen Spears",
+			  "level": 20,
+			  "materials": {
+				"dragon-tempered": 400,
+				"hide": 400,
+				"goldenheart-wood": 400,
+				"leather-straps": 400
+			  },
+			  "img": "item/season8/dragon-rider/weapon.png"
+			},
+			{
+			  "name": "Jeweled Adornment",
+			  "level": 25,
+			  "materials": {
+				"dragon-tempered": 1200,
+				"wildfire": 1200,
+				"dragonglass": 1200,
+				"milk-of-the-poppy": 1200
+			  },
+			  "img": "item/season8/dragon-rider/head.png"
+			},
+			{
+			  "name": "Jacket",
+			  "level": 25,
+			  "materials": {
+				"dragon-tempered": 1200,
+				"kingswood-oak": 1200,
+				"copper-bar": 1200,
+				"goldenheart-wood": 1200
+			  },
+			  "img": "item/season8/dragon-rider/chest.png"
+			},
+			{
+			  "name": "Bases",
+			  "level": 25,
+			  "materials": {
+				"dragon-tempered": 1200,
+				"ironwood": 1200,
+				"wildfire": 1200,
+				"copper-bar": 1200
+			  },
+			  "img": "item/season8/dragon-rider/pants.png"
+			},
+			{
+			  "name": "Heeled Boots",
+			  "level": 25,
+			  "materials": {
+				"dragon-tempered": 1200,
+				"milk-of-the-poppy": 1200,
+				"kingswood-oak": 1200,
+				"ironwood": 1200
+			  },
+			  "img": "item/season8/dragon-rider/boots.png"
+			},
+			{
+			  "name": "Encrusted Ring",
+			  "level": 25,
+			  "materials": {
+				"dragon-tempered": 1200,
+				"weirwood": 1200,
+				"black-iron": 1200,
+				"silk": 1200
+			  },
+			  "img": "item/season8/dragon-rider/ring.png"
+			},
+			{
+			  "name": "Keen Spears",
+			  "level": 25,
+			  "materials": {
+				"dragon-tempered": 1200,
+				"hide": 1200,
+				"goldenheart-wood": 1200,
+				"leather-straps": 1200
+			  },
+			  "img": "item/season8/dragon-rider/weapon.png"
+			}
+		  ]
+		}
+	]
+};


### PR DESCRIPTION
## Summary
- keep template input labels active when loading via shared link
- remove `share` query parameter after loading shared data

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685076fe332483229e3b33089b768f15