### PR TITLE
Add screenshot capture and template info popup

### DIFF
--- a/craftparse.js
+++ b/craftparse.js
@@ -134,6 +134,19 @@ document.addEventListener('DOMContentLoaded', function() {
             scalePopup.style.display = 'none';
         }
     });
+
+    const templatesBtn = document.getElementById('templatesInfoBtn');
+    const templatesPopup = document.getElementById('templatesInfoPopup');
+    templatesBtn?.addEventListener('click', () => {
+        if (templatesPopup) {
+            templatesPopup.style.display = 'flex';
+        }
+    });
+    templatesPopup?.addEventListener('click', (e) => {
+        if (e.target === templatesPopup || e.target.closest('.close-popup')) {
+            templatesPopup.style.display = 'none';
+        }
+    });
 });
 
 function formatPlaceholderWithCommas(number) {
@@ -303,22 +316,21 @@ function createCloseButton(parentElement) {
     parentElement.appendChild(closeButton);
 }
 
-function createCopyButton(data) {
-    const copyButton = document.createElement('button');
-    copyButton.id = 'copyLink';
-    copyButton.innerHTML = `Copy this calculation <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M288 240l-96 0c-66.2 0-122 44.7-138.8 105.5C49.9 333.1 48 319.3 48 304c0-70.7 57.3-128 128-128l112 0 24 0c13.3 0 24-10.7 24-24l0-24 0-28.1L456.1 208 336 316.1l0-28.1 0-24c0-13.3-10.7-24-24-24l-24 0zm0 48l0 48 0 16c0 12.6 7.4 24.1 19 29.2s25 3 34.4-5.4l160-144c6.7-6.1 10.6-14.7 10.6-23.8s-3.8-17.7-10.6-23.8l-160-144c-9.4-8.5-22.9-10.6-34.4-5.4s-19 16.6-19 29.2l0 16 0 48-48 0-64 0C78.8 128 0 206.8 0 304c0 78 38.6 126.2 68.7 152.1c4.1 3.5 8.1 6.6 11.7 9.3c3.2 2.4 6.2 4.4 8.9 6.2c4.5 3 8.3 5.1 10.8 6.5c2.5 1.4 5.3 1.9 8.1 1.9c10.9 0 19.7-8.9 19.7-19.7c0-6.8-3.6-13.2-8.3-18.1c-.5-.5-.9-.9-1.4-1.4c-2.4-2.3-5.1-5.1-7.7-8.6c-1.7-2.3-3.4-5-5-7.9c-5.3-9.7-9.5-22.9-9.5-40.2c0-53 43-96 96-96l48 0 48 0z"/></svg>`;
-    copyButton.addEventListener('click', () => {
-        const encoded = btoa(JSON.stringify(data))
-            .replace(/\+/g, '-')
-            .replace(/\//g, '_')
-            .replace(/=+$/, '');
-        const url = `${window.location.origin}${window.location.pathname}?share=${encoded}`;
-        navigator.clipboard.writeText(url).then(() => {
-            copyButton.textContent = 'Copied!';
-            setTimeout(() => { copyButton.innerHTML = `Copy this calculation <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M288 240l-96 0c-66.2 0-122 44.7-138.8 105.5C49.9 333.1 48 319.3 48 304c0-70.7 57.3-128 128-128l112 0 24 0c13.3 0 24-10.7 24-24l0-24 0-28.1L456.1 208 336 316.1l0-28.1 0-24c0-13.3-10.7-24-24-24l-24 0zm0 48l0 48 0 16c0 12.6 7.4 24.1 19 29.2s25 3 34.4-5.4l160-144c6.7-6.1 10.6-14.7 10.6-23.8s-3.8-17.7-10.6-23.8l-160-144c-9.4-8.5-22.9-10.6-34.4-5.4s-19 16.6-19 29.2l0 16 0 48-48 0-64 0C78.8 128 0 206.8 0 304c0 78 38.6 126.2 68.7 152.1c4.1 3.5 8.1 6.6 11.7 9.3c3.2 2.4 6.2 4.4 8.9 6.2c4.5 3 8.3 5.1 10.8 6.5c2.5 1.4 5.3 1.9 8.1 1.9c10.9 0 19.7-8.9 19.7-19.7c0-6.8-3.6-13.2-8.3-18.1c-.5-.5-.9-.9-1.4-1.4c-2.4-2.3-5.1-5.1-7.7-8.6c-1.7-2.3-3.4-5-5-7.9c-5.3-9.7-9.5-22.9-9.5-40.2c0-53 43-96 96-96l48 0 48 0z"/></svg>`; }, 2000);
-        });
+function createScreenshotButton() {
+    const button = document.createElement('button');
+    button.id = 'screenshotBtn';
+    button.innerHTML = `Capture screenshot <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M288 240l-96 0c-66.2 0-122 44.7-138.8 105.5C49.9 333.1 48 319.3 48 304c0-70.7 57.3-128 128-128l112 0 24 0c13.3 0 24-10.7 24-24l0-24 0-28.1L456.1 208 336 316.1l0-28.1 0-24c0-13.3-10.7-24-24-24l-24 0zm0 48l0 48 0 16c0 12.6 7.4 24.1 19 29.2s25 3 34.4-5.4l160-144c6.7-6.1 10.6-14.7 10.6-23.8s-3.8-17.7-10.6-23.8l-160-144c-9.4-8.5-22.9-10.6-34.4-5.4s-19 16.6-19 29.2l0 16 0 48-48 0-64 0C78.8 128 0 206.8 0 304c0 78 38.6 126.2 68.7 152.1c4.1 3.5 8.1 6.6 11.7 9.3c3.2 2.4 6.2 4.4 8.9 6.2c4.5 3 8.3 5.1 10.8 6.5c2.5 1.4 5.3 1.9 8.1 1.9c10.9 0 19.7-8.9 19.7-19.7c0-6.8-3.6-13.2-8.3-18.1c-.5-.5-.9-.9-1.4-1.4c-2.4-2.3-5.1-5.1-7.7-8.6c-1.7-2.3-3.4-5-5-7.9c-5.3-9.7-9.5-22.9-9.5-40.2c0-53 43-96 96-96l48 0 48 0z"/></svg>`;
+    button.addEventListener('click', () => {
+        if (window.html2canvas) {
+            html2canvas(document.body, {scrollY: -window.scrollY}).then(canvas => {
+                const link = document.createElement('a');
+                link.download = 'screenshot.png';
+                link.href = canvas.toDataURL('image/png');
+                link.click();
+            });
+        }
     });
-    return copyButton;
+    return button;
 }
 
 function createLevelStructure() {
@@ -679,10 +691,9 @@ function renderResults(templateCounts, materialCounts) {
             warlord
         }));
     });
-    const shareData = { templates: minimalTemplates, initialMaterials };
-    const copyBtn = createCopyButton(shareData);
-    generateDiv.after(copyBtn);
-    copyBtn.after(itemsDiv);
+    const screenshotBtn = createScreenshotButton();
+    generateDiv.after(screenshotBtn);
+    screenshotBtn.after(itemsDiv);
     itemsDiv.after(itemsInfoPopup);
     createCloseButton(resultsDiv);
 

--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
     <script src="products.js"></script>
     <script src="materials.js"></script>
     <script defer src="craftparse.js?v=1.111"></script>
+    <script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>
 	<script async src="https://www.googletagmanager.com/gtag/js?id=G-3KDS4M7C1F"></script>
 	<script>
 	  window.dataLayer = window.dataLayer || [];
@@ -78,8 +79,11 @@
 			</div>
 			
 
-			<!-- Generoitavien itemien määrä -->
-                        <div class="section-title"><div class="checkbox-header"><span>Enter number of templates</span></div></div>
+                        <!-- Generoitavien itemien määrä -->
+                        <div class="section-title"><div class="checkbox-header"><span>Enter number of templates</span><button id="templatesInfoBtn" class="info-btn" aria-label="Template info">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336c-13.3 0-24 10.7-24 24s10.7 24 24 24l80 0c13.3 0 24-10.7 24-24s-10.7-24-24-24l-8 0 0-88c0-13.3-10.7-24-24-24l-48 0c-13.3 0-24 10.7-24 24s10.7 24 24 24l24 0 0 64-24 0zm40-144a32 32 0 1 0 0-64 32 32 0 1 0 0 64z"/></svg>
+                                </button></div></div>
+                        <div id="templatesInfoPopup" class="info-overlay"><div class="info-content"><button class="close-popup" aria-label="Close"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><path d="M345 137c9.4-9.4 9.4-24.6 0-33.9s-24.6-9.4-33.9 0l-119 119L73 103c-9.4-9.4-24.6-9.4-33.9 0s-9.4 24.6 0 33.9l119 119L39 375c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l119-119L311 409c9.4 9.4 24.6 9.4 33.9 0s9.4-24.6 0-33.9l-119-119L345 137z"/></svg></button><p>Define the desired number of templates for each level. Use the dropdown on the same line to choose the material quality for that template.</p></div></div>
 			<div class="leveltmp1">
 				<div class="templateAmountWrap">
 					<label for="templateAmount1">level 1</label>

--- a/style.css
+++ b/style.css
@@ -296,7 +296,7 @@ footer div {
         background: none;
         width: max-content;
 }
-#copyLink {
+#screenshotBtn {
     font-size: 14px;
     cursor: pointer;
     background: initial;
@@ -307,21 +307,21 @@ footer div {
     justify-content: center;
     align-items: center;
 }
-#results #copyLink svg {
+#results #screenshotBtn svg {
     fill: var(--primary-color);
     padding-left: 10px;
     height: 18px;
 }
-#results #copyLink svg:hover {
-	transform: rotate(0deg);
-	fill: initial;
+#results #screenshotBtn svg:hover {
+        transform: rotate(0deg);
+        fill: initial;
 }
 div#results h3 ~ #closeResults {
     margin: 0;
     top: -40px;
     right: -20px;
 }
-div#results h3 ~ #copyLink {
+div#results h3 ~ #screenshotBtn {
     top: -40px;
     right: 20px;
 }


### PR DESCRIPTION
## Summary
- replace copy link feature with screenshot capture using html2canvas
- add info button for template entry section
- style screenshot button
- load html2canvas from CDN

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_685d9fcdf6e483229a948120a438bbf2