### PR TITLE
Fix screenshot background and aspect ratio

### DIFF
--- a/craftparse.js
+++ b/craftparse.js
@@ -326,9 +326,9 @@ function createScreenshotButton() {
             const prevDisplay = button.style.display;
             button.style.display = 'none';
             html2canvas(target, {
-                scrollY: -window.scrollY,
-                scrollX: -window.scrollX,
-                useCORS: true
+                useCORS: true,
+                backgroundColor: null,
+                scale: 1
             }).then(canvas => {
                 button.style.display = prevDisplay;
                 const link = document.createElement('a');


### PR DESCRIPTION
## Summary
- adjust screenshot options so background color renders correctly
- remove scrolling offsets and fix scale to preserve aspect ratio

## Testing
- `node --check craftparse.js`

------
https://chatgpt.com/codex/tasks/task_b_685da5a03ff08322bd2ac36788259f59