### PR TITLE
Fix screenshot background

### DIFF
--- a/craftparse.js
+++ b/craftparse.js
@@ -326,8 +326,10 @@ function createScreenshotButton() {
             const prevDisplay = button.style.display;
             button.style.display = 'none';
             html2canvas(target, {
+                scrollY: -window.scrollY,
+                scrollX: -window.scrollX,
                 useCORS: true,
-                backgroundColor: null,
+                backgroundColor: '#ffffff',
                 scale: 1
             }).then(canvas => {
                 button.style.display = prevDisplay;


### PR DESCRIPTION
## Summary
- adjust html2canvas options so captured screenshots use a white background and correct offsets

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_685da8f8d79483229fdc63fb09e883b5