### PR TITLE
Fix CTW medium odds fallback logic

### DIFF
--- a/craftparse.js
+++ b/craftparse.js
@@ -592,7 +592,7 @@ function renderResults(templateCounts, materialCounts) {
             if (lvl === 20 && ctwMediumNotice) {
                 const extraInfo = document.createElement('p');
                 extraInfo.className = 'craft-extra-info';
-                extraInfo.textContent = "Poikkeuksellisesti 'Medium odds' tason itemeitä on käytetty, koska muuten laskelma ei saisi yhtään itemiä. Tasolla 20, Ceremonial Targaryen Warlord itemit kuuluu 'medium odds' tason piiriin.";
+                extraInfo.textContent = "Medium odds items were used because otherwise no items would be generated. At level 20, Ceremonial Targaryen Warlord items are categorized as 'medium odds'.";
                 itemsDiv.appendChild(extraInfo);
             }
 
@@ -933,7 +933,11 @@ function calculateProductionPlan(availableMaterials, templatesByLevel) {
     const includeMediumOdds = document.getElementById('includeMediumOdds')?.checked ?? true;
     const gearLevelSelect = document.getElementById('gearMaterialLevels');
     const allowedGearLevels = gearLevelSelect ? Array.from(gearLevelSelect.selectedOptions).map(o => parseInt(o.value, 10)) : [];
-    ctwMediumNotice = includeWarlords && !includeMediumOdds && !allowedGearLevels.includes(20);
+    const hasGearMaterials = Object.keys(availableMaterials).some(
+        key => (materialToSeason[key] || 0) !== 0
+    );
+    const level20Allowed = hasGearMaterials && allowedGearLevels.includes(20);
+    ctwMediumNotice = includeWarlords && !includeMediumOdds && !level20Allowed;
 
     // Craft level 15 items first when only normal odds are allowed and
     // no CTW or gear materials are in use at that level.
@@ -1396,7 +1400,7 @@ function initAdvMaterialSection() {
     const infoPopup = document.createElement('div');
     infoPopup.id = 'gearLevelsInfoPopup';
     infoPopup.className = 'info-overlay';
-    infoPopup.innerHTML = '<div class="info-content"><button class="close-popup" aria-label="Close"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><path d="M345 137c9.4-9.4 9.4-24.6 0-33.9s-24.6-9.4-33.9 0l-119 119L73 103c-9.4-9.4-24.6-9.4-33.9 0s-9.4 24.6 0 33.9l119 119L39 375c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l119-119L311 409c9.4 9.4 24.6 9.4 33.9 0s9.4-24.6 0-33.9l-119-119L345 137z"></path></svg></button><p>Select the levels where gear set materials may be used. Other levels craft only with basic materials, allowing you to save gear materials for later levels.</p></div>';
+    infoPopup.innerHTML = '<div class="info-content"><button class="close-popup" aria-label="Close"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><path d="M345 137c9.4-9.4 9.4-24.6 0-33.9s-24.6-9.4-33.9 0l-119 119L73 103c-9.4-9.4-24.6-9.4-33.9 0s-9.4 24.6 0 33.9l119 119L39 375c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l119-119L311 409c9.4 9.4 24.6 9.4 33.9 0s9.4-24.6 0-33.9l-119-119L345 137z"></path></svg></button><p>Select the levels where gear set materials may be used. Other levels craft only with basic materials, allowing you to save gear materials for later levels. Levels with a dark background are active.</p></div>';
     container.appendChild(infoPopup);
 
     const levelWrap = document.createElement('div');


### PR DESCRIPTION
## Summary
- refine CTW level 20 fallback check so it ignores default gear level when no gear materials are provided
- clarify gear materials info overlay that dark background levels are active

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_b_685fdfd39f388322bf9d395240a85956