### PR TITLE
Implement fallback odds when CTW is disabled

### DIFF
--- a/craftparse.js
+++ b/craftparse.js
@@ -659,13 +659,13 @@ function renderResults(templateCounts, materialCounts) {
             if (lvl === 20 && lowOddsNotice) {
                 const extraInfo = document.createElement('p');
                 extraInfo.className = 'craft-extra-info';
-                extraInfo.textContent = "Low odds items were used because CTW was not selected.";
+                extraInfo.textContent = "Low odds items were used because otherwise no items would be generated.";
                 itemsDiv.appendChild(extraInfo);
             }
             if (lvl === 25 && mediumOddsNotice25) {
                 const extraInfo = document.createElement('p');
                 extraInfo.className = 'craft-extra-info';
-                extraInfo.textContent = "Medium odds items were used because CTW was not selected.";
+                extraInfo.textContent = "Medium odds items were used because otherwise no items would be generated.";
                 itemsDiv.appendChild(extraInfo);
             }
 

--- a/craftparse.js
+++ b/craftparse.js
@@ -25,6 +25,8 @@ let failedLevels = [];
 let requestedTemplates = {};
 let remainingUse = {};
 let ctwMediumNotice = false;
+let lowOddsNotice = false;
+let mediumOddsNotice25 = false;
 
 function slug(str) {
     return (str || '')
@@ -654,6 +656,18 @@ function renderResults(templateCounts, materialCounts) {
                 extraInfo.textContent = "Medium odds items were used because otherwise no items would be generated. At level 20, Ceremonial Targaryen Warlord items are categorized as 'medium odds'.";
                 itemsDiv.appendChild(extraInfo);
             }
+            if (lvl === 20 && lowOddsNotice) {
+                const extraInfo = document.createElement('p');
+                extraInfo.className = 'craft-extra-info';
+                extraInfo.textContent = "Low odds items were used because CTW was not selected.";
+                itemsDiv.appendChild(extraInfo);
+            }
+            if (lvl === 25 && mediumOddsNotice25) {
+                const extraInfo = document.createElement('p');
+                extraInfo.className = 'craft-extra-info';
+                extraInfo.textContent = "Medium odds items were used because CTW was not selected.";
+                itemsDiv.appendChild(extraInfo);
+            }
 
             const levelGroup = document.createElement('div');
             levelGroup.className = 'level-group';
@@ -999,6 +1013,8 @@ function calculateProductionPlan(availableMaterials, templatesByLevel) {
     );
     const level20Allowed = hasGearMaterials && allowedGearLevels.includes(20);
     ctwMediumNotice = includeWarlords && !includeMediumOdds && !level20Allowed;
+    lowOddsNotice = !includeWarlords && !includeMediumOdds && !includeLowOdds;
+    mediumOddsNotice25 = !includeWarlords && !includeMediumOdds;
 
     // Craft level 15 items first when only normal odds are allowed and
     // no CTW or gear materials are in use at that level.
@@ -1054,8 +1070,8 @@ function calculateProductionPlan(availableMaterials, templatesByLevel) {
         levelProducts = levelProducts.filter(p => {
             const applyOdds = !isLegendary && (p.season === 0 || (p.level === 20 && (p.season === 1 || p.season === 2)));
             if (!applyOdds || !p.odds) return true;
-            if (p.odds === 'low') return includeLowOdds;
-            if (p.odds === 'medium') return includeMediumOdds || (ctwMediumNotice && p.warlord && p.level === 20);
+            if (p.odds === 'low') return includeLowOdds || (lowOddsNotice && p.level === 20);
+            if (p.odds === 'medium') return includeMediumOdds || (ctwMediumNotice && p.warlord && p.level === 20) || (mediumOddsNotice25 && p.level === 25);
             return true;
         });
         levelProducts = filterProductsByAvailableGear(levelProducts, availableMaterials, multiplier);
@@ -1085,8 +1101,8 @@ function calculateProductionPlan(availableMaterials, templatesByLevel) {
             levelProducts = levelProducts.filter(p => {
                 const applyOdds = !isLegendary && (p.season === 0 || (p.level === 20 && (p.season === 1 || p.season === 2)));
                 if (!applyOdds || !p.odds) return true;
-                if (p.odds === 'low') return includeLowOdds;
-                if (p.odds === 'medium') return includeMediumOdds || (ctwMediumNotice && p.warlord && p.level === 20);
+                if (p.odds === 'low') return includeLowOdds || (lowOddsNotice && p.level === 20);
+                if (p.odds === 'medium') return includeMediumOdds || (ctwMediumNotice && p.warlord && p.level === 20) || (mediumOddsNotice25 && p.level === 25);
                 return true;
             });
             levelProducts = filterProductsByAvailableGear(levelProducts, availableMaterials, multiplier);

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
 	<script src="seasons/season12.js"></script>
     <script src="products.js"></script>
     <script src="materials.js"></script>
-    <script defer src="craftparse.js?v=1.111"></script>
+    <script defer src="craftparse.js?v=1.112"></script>
 	<script async src="https://www.googletagmanager.com/gtag/js?id=G-3KDS4M7C1F"></script>
 	<script>
 	  window.dataLayer = window.dataLayer || [];


### PR DESCRIPTION
## Summary
- allow fallback to low odds at level 20 when CTW and medium odds are not selected
- allow fallback to medium odds at level 25 when CTW is not selected
- display info messages when these fallbacks are used
- bump craftparse version in `index.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_68616631fbf88322815035197fb5d11d