### PR TITLE
Add per-season extra level data

### DIFF
--- a/craftparse.js
+++ b/craftparse.js
@@ -2,7 +2,7 @@ let initialMaterials = {};
 const urlParams = new URLSearchParams(window.location.search);
 const isDebugMode = urlParams.has('debug') && urlParams.get('debug') === 'true';
 
-const LEVELS = [1, 5, 10, 15, 20, 25];
+const LEVELS = [1, 5, 10, 15, 20, 25, 30, 35, 40, 45];
 const allMaterials = Object.values(materials).reduce((acc, season) => {
     return { ...acc, ...season.mats };
 }, {});
@@ -448,7 +448,7 @@ function calculateMaterials() {
 
     // Täytä materialsDiv materiaalien tiedoilla...
 
-    const templateCounts = { 1: [], 5: [], 10: [], 15: [], 20: [], 25: [] };
+    const templateCounts = { 1: [], 5: [], 10: [], 15: [], 20: [], 25: [], 30: [], 35: [], 40: [], 45: [] };
     const materialCounts = {};
     
     // Kerää tiedot kaikista syötetyistä itemeistä
@@ -1000,7 +1000,7 @@ function filterProductsByAvailableGear(products, availableMaterials, multiplier 
 }
 
 function calculateProductionPlan(availableMaterials, templatesByLevel) {
-    let productionPlan = { "1": [], "5": [], "10": [], "15": [], "20": [], "25": [] };
+    let productionPlan = { "1": [], "5": [], "10": [], "15": [], "20": [], "25": [], "30": [], "35": [], "40": [], "45": [] };
     const failed = new Set();
     const includeWarlords = document.getElementById('includeWarlords')?.checked ?? true;
     const level1OnlyWarlords = document.getElementById('level1OnlyWarlords')?.checked ?? false;
@@ -1374,7 +1374,7 @@ function inputActive(){
     });		
 
 	// Uusi osa: käsittele kaikki templateAmount-inputit tasoittain (1,5,10,...)
-	const levels = [1, 5, 10, 15, 20, 25];
+        const levels = [1, 5, 10, 15, 20, 25, 30, 35, 40, 45];
 	levels.forEach(level => {
 		const input = document.querySelector(`#templateAmount${level}`);
 		const wrap = document.querySelector(`.leveltmp${level} .templateAmountWrap`);
@@ -1490,7 +1490,7 @@ function initAdvMaterialSection() {
     select.multiple = true;
     select.style.display = 'none';
 
-    [5,10,15,20,25].forEach(l => {
+    [5,10,15,20,25,30,35,40,45].forEach(l => {
         const optionDiv = document.createElement('div');
         optionDiv.dataset.value = l;
         optionDiv.textContent = l;

--- a/index.html
+++ b/index.html
@@ -153,20 +153,76 @@
 					<option value="legendary">Legendary</option>
 				</select>
 			</div>
-			<div class="leveltmp25">
-				<div class="templateAmountWrap">
-					<label for="templateAmount25">level 25</label>
-					<input type="number" id="templateAmount25" placeholder="120" min="0">
-				</div>
-				<select name="temp25" id="temp25" class="temps">
-					<option value="poor">Poor</option>
-					<option value="common">Common</option>
-					<option value="fine">Fine</option>
-					<option value="exquisite" selected>Exquisite</option>
-					<option value="epic">Epic</option>
-					<option value="legendary">Legendary</option>
-				</select>
-			</div>
+                        <div class="leveltmp25">
+                                <div class="templateAmountWrap">
+                                        <label for="templateAmount25">level 25</label>
+                                        <input type="number" id="templateAmount25" placeholder="120" min="0">
+                                </div>
+                                <select name="temp25" id="temp25" class="temps">
+                                        <option value="poor">Poor</option>
+                                        <option value="common">Common</option>
+                                        <option value="fine">Fine</option>
+                                        <option value="exquisite" selected>Exquisite</option>
+                                        <option value="epic">Epic</option>
+                                        <option value="legendary">Legendary</option>
+                                </select>
+                        </div>
+                        <div class="leveltmp30">
+                                <div class="templateAmountWrap">
+                                        <label for="templateAmount30">level 30</label>
+                                        <input type="number" id="templateAmount30" placeholder="120" min="0">
+                                </div>
+                                <select name="temp30" id="temp30" class="temps">
+                                        <option value="poor">Poor</option>
+                                        <option value="common">Common</option>
+                                        <option value="fine">Fine</option>
+                                        <option value="exquisite" selected>Exquisite</option>
+                                        <option value="epic">Epic</option>
+                                        <option value="legendary">Legendary</option>
+                                </select>
+                        </div>
+                        <div class="leveltmp35">
+                                <div class="templateAmountWrap">
+                                        <label for="templateAmount35">level 35</label>
+                                        <input type="number" id="templateAmount35" placeholder="120" min="0">
+                                </div>
+                                <select name="temp35" id="temp35" class="temps">
+                                        <option value="poor">Poor</option>
+                                        <option value="common">Common</option>
+                                        <option value="fine" selected>Fine</option>
+                                        <option value="exquisite">Exquisite</option>
+                                        <option value="epic">Epic</option>
+                                        <option value="legendary">Legendary</option>
+                                </select>
+                        </div>
+                        <div class="leveltmp40">
+                                <div class="templateAmountWrap">
+                                        <label for="templateAmount40">level 40</label>
+                                        <input type="number" id="templateAmount40" placeholder="120" min="0">
+                                </div>
+                                <select name="temp40" id="temp40" class="temps">
+                                        <option value="poor">Poor</option>
+                                        <option value="common">Common</option>
+                                        <option value="fine" selected>Fine</option>
+                                        <option value="exquisite">Exquisite</option>
+                                        <option value="epic">Epic</option>
+                                        <option value="legendary">Legendary</option>
+                                </select>
+                        </div>
+                        <div class="leveltmp45">
+                                <div class="templateAmountWrap">
+                                        <label for="templateAmount45">level 45</label>
+                                        <input type="number" id="templateAmount45" placeholder="120" min="0">
+                                </div>
+                                <select name="temp45" id="temp45" class="temps">
+                                        <option value="poor">Poor</option>
+                                        <option value="common" selected>Common</option>
+                                        <option value="fine">Fine</option>
+                                        <option value="exquisite">Exquisite</option>
+                                        <option value="epic">Epic</option>
+                                        <option value="legendary">Legendary</option>
+                                </select>
+                        </div>
 			
                         <div class="section-title"><div class="checkbox-header"><span>Ceremonial Targaryen Warlord</span><button id="ctwInfoBtn" class="info-btn" aria-label="CTW info">
                                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336c-13.3 0-24 10.7-24 24s10.7 24 24 24l80 0c13.3 0 24-10.7 24-24s-10.7-24-24-24l-8 0 0-88c0-13.3-10.7-24-24-24l-48 0c-13.3 0-24 10.7-24 24s10.7 24 24 24l24 0 0 64-24 0zm40-144a32 32 0 1 0 0-64 32 32 0 1 0 0 64z"/></svg>

--- a/products.js
+++ b/products.js
@@ -91,7 +91,47 @@ let craftItem = {
 						season: season12.season
 				}))
 		)
-	]
+        ]
 };
 
-window.seasons = [season0, season1, season2, season3, season4, season5, season6, season7, season8, season9, season10, season11, season12];
+const seasonsMap = {
+  0: season0,
+  1: season1,
+  2: season2,
+  3: season3,
+  4: season4,
+  5: season5,
+  6: season6,
+  7: season7,
+  8: season8,
+  9: season9,
+  10: season10,
+  11: season11,
+  12: season12,
+};
+
+const extraProducts = [];
+
+craftItem.products.forEach(product => {
+  if (product.level === 25 && product.season !== 0) {
+    const extraLevels = seasonsMap[product.season]?.extraLevels;
+    if (extraLevels) {
+      Object.entries(extraLevels).forEach(([lvl, amt]) => {
+        const ratio = amt / 1200;
+        const mats = {};
+        Object.entries(product.materials).forEach(([mat, val]) => {
+          mats[mat] = val * ratio;
+        });
+        extraProducts.push({
+          ...product,
+          level: parseInt(lvl, 10),
+          materials: mats,
+        });
+      });
+    }
+  }
+});
+
+craftItem.products.push(...extraProducts);
+
+window.seasons = Object.values(seasonsMap);

--- a/seasons/season1.js
+++ b/seasons/season1.js
@@ -1,6 +1,7 @@
 const season1 = {
-	season: 1,
-	sets: [
+        season: 1,
+        extraLevels: {30: 3000, 35: 12000, 40: 45000, 45: 120000},
+        sets: [
 		{
 		  "setName": "Corsair's",
 		  "setMat": "Abalone",

--- a/seasons/season10.js
+++ b/seasons/season10.js
@@ -1,6 +1,7 @@
 const season10 = {
-	season: 10,
-	sets: [
+        season: 10,
+        extraLevels: {30: 3000, 35: 12000, 40: 45000, 45: 120000},
+        sets: [
 		{
 			setName: "Fishmonger",
 			setMat: "Fishmongers Fishing Net",

--- a/seasons/season11.js
+++ b/seasons/season11.js
@@ -1,6 +1,7 @@
 const season11 = {
-	season: 11,
-	sets: [
+        season: 11,
+        extraLevels: {30: 3000, 35: 12000, 40: 45000, 45: 120000},
+        sets: [
 		{
 		  "setName": "Flame Lit Lanister",
 		  "setMat": "Ash Cloaked Clow",

--- a/seasons/season12.js
+++ b/seasons/season12.js
@@ -1,6 +1,7 @@
 const season12 = {
-	season: 12,
-	sets: [
+        season: 12,
+        extraLevels: {30: 3000, 35: 12000, 40: 45000, 45: 120000},
+        sets: [
 		{
 		  "setName": "Burning Usurper's",
 		  "setMat": "Burning Stag Hide",

--- a/seasons/season2.js
+++ b/seasons/season2.js
@@ -1,6 +1,7 @@
 const season2 = {
-	season: 2,
-	sets: [
+        season: 2,
+        extraLevels: {30: 3000, 35: 12000, 40: 45000, 45: 120000},
+        sets: [
 		{
 		  "setName": "Siege Engineer's",
 		  "setMat": "Bucket of Tar",

--- a/seasons/season3.js
+++ b/seasons/season3.js
@@ -1,6 +1,7 @@
 const season3 = {
-	season: 3,
-	sets: [
+        season: 3,
+        extraLevels: {30: 3000, 35: 12000, 40: 45000, 45: 120000},
+        sets: [
 		{
 		  "setName": "Stark Relic",
 		  "setMat": "Ancient Leather",

--- a/seasons/season4.js
+++ b/seasons/season4.js
@@ -1,6 +1,7 @@
 const season4 = {
-	season: 4,
-	sets: [
+        season: 4,
+        extraLevels: {30: 3000, 35: 12000, 40: 45000, 45: 120000},
+        sets: [
 		{
 		  "setName": "Dragonkeeper's",
 		  "setMat": "Black Scalemail",

--- a/seasons/season5.js
+++ b/seasons/season5.js
@@ -1,6 +1,7 @@
 const season5 = {
-	season: 5,
-	sets: [
+        season: 5,
+        extraLevels: {30: 3000, 35: 12000, 40: 45000, 45: 120000},
+        sets: [
 		{
 		  "setName": "Fiery Zealot's",
 		  "setMat": "Crimson Taffeta",

--- a/seasons/season6.js
+++ b/seasons/season6.js
@@ -1,6 +1,7 @@
 const season6 = {
-	season: 6,
-	sets: [
+        season: 6,
+        extraLevels: {30: 3000, 35: 12000, 40: 45000, 45: 120000},
+        sets: [
 		{
 		  "setName": "Crannogman Trapper's",
 		  "setMat": "Alligator Skins",

--- a/seasons/season7.js
+++ b/seasons/season7.js
@@ -1,6 +1,7 @@
 const season7 = {
-	season: 7,
-	sets: [
+        season: 7,
+        extraLevels: {30: 3000, 35: 12000, 40: 45000, 45: 120000},
+        sets: [
 		{
 		  "setName": "Storm Lord's",
 		  "setMat": "Boiled Leather",

--- a/seasons/season8.js
+++ b/seasons/season8.js
@@ -1,6 +1,7 @@
 const season8 = {
-	season: 8,
-	sets: [
+        season: 8,
+        extraLevels: {30: 3000, 35: 12000, 40: 45000, 45: 120000},
+        sets: [
 		{
 		  "setName": "Living Mountain's",
 		  "setMat": "Dark Steel Plate",

--- a/seasons/season9.js
+++ b/seasons/season9.js
@@ -1,6 +1,7 @@
 const season9 = {
-	season: 9,
-	sets: [
+        season: 9,
+        extraLevels: {30: 3000, 35: 12000, 40: 45000, 45: 120000},
+        sets: [
 		{
 		  "setName": "Thenn Tribal",
 		  "setMat": "Bronze Discs",


### PR DESCRIPTION
## Summary
- add `extraLevels` metadata to season1-12
- generate higher-level templates using each season's extra level table

## Testing
- `node --check products.js`
- `node --check craftparse.js`


------
https://chatgpt.com/codex/tasks/task_b_6861abb1f724832298614cdf4b4b4c29