### PR TITLE
Add checkbox to reuse existing items

### DIFF
--- a/index.html
+++ b/index.html
@@ -265,6 +265,13 @@
                             </span>
                             <label for="includeMediumOdds">Include medium odds items</label>
                         </div>
+                        <div class="warlord-toggle checkbox-wrapper-30">
+                            <span class="checkbox">
+                                <input type="checkbox" id="preferSameItems">
+                                <svg><use xlink:href="#checkbox-30"></use></svg>
+                            </span>
+                            <label for="preferSameItems">Favor same items</label>
+                        </div>
                         <svg xmlns="http://www.w3.org/2000/svg" style="display:none">
                             <symbol id="checkbox-30" viewBox="0 0 22 22">
                                 <path fill="none" stroke="currentColor" d="M5.5,11.3L9,14.8L20.2,3.3l0,0c-0.5-1-1.5-1.8-2.7-1.8h-13c-1.7,0-3,1.3-3,3v13c0,1.7,1.3,3,3,3h13 c1.7,0,3-1.3,3-3v-13c0-0.4-0.1-0.8-0.3-1.2"/>


### PR DESCRIPTION
## Summary
- add optional checkbox to favor same items during template calculation
- track picked items per level and weight reuse with a new constant
- account for the checkbox in `calculateProductionPlan`

## Testing
- `node --check craftparse.js`

------
https://chatgpt.com/codex/tasks/task_b_68695c364c4883229d010977b5942297