### PR TITLE
Color-code template quality dropdowns

### DIFF
--- a/craftparse.js
+++ b/craftparse.js
@@ -223,6 +223,39 @@ document.addEventListener('DOMContentLoaded', function() {
             }
         });
     });
+
+    const qualityColorMap = {
+        poor: '#A9A9A9',
+        common: '#32CD32',
+        fine: '#0070DD',
+        exquisite: '#A335EE',
+        epic: '#FF8000',
+        legendary: '#E5CC80'
+    };
+
+    function getContrastColor(hex) {
+        const r = parseInt(hex.substr(1, 2), 16);
+        const g = parseInt(hex.substr(3, 2), 16);
+        const b = parseInt(hex.substr(5, 2), 16);
+        const yiq = (r * 299 + g * 587 + b * 114) / 1000;
+        return yiq >= 128 ? '#000' : '#fff';
+    }
+
+    document.querySelectorAll('select.temps').forEach(select => {
+        const applyColor = () => {
+            const color = qualityColorMap[select.value];
+            if (color) {
+                select.style.backgroundColor = color;
+                select.style.color = getContrastColor(color);
+            } else {
+                select.style.removeProperty('background-color');
+                select.style.removeProperty('color');
+            }
+        };
+
+        select.addEventListener('change', applyColor);
+        applyColor();
+    });
 });
 
 function formatPlaceholderWithCommas(number) {

--- a/index.html
+++ b/index.html
@@ -28,8 +28,8 @@
     <script src="products.js"></script>
     <script src="materials.js"></script>
     <script defer src="craftparse.js?v=1.112"></script>
-	<script async src="https://www.googletagmanager.com/gtag/js?id=G-3KDS4M7C1F"></script>
-	<script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-3KDS4M7C1F"></script>
+    <script>
 	  window.dataLayer = window.dataLayer || [];
 	  function gtag(){dataLayer.push(arguments);}
 	  gtag('js', new Date());

--- a/style.css
+++ b/style.css
@@ -50,6 +50,39 @@ h1.calc-header {
     box-sizing: border-box;
     border-radius: 4px;
 }
+
+/* Color-coded options for template quality */
+.temps option[value="poor"] {
+    background-color: #A9A9A9;
+    color: #000;
+}
+.temps option[value="common"] {
+    background-color: #32CD32;
+    color: #000;
+}
+.temps option[value="fine"] {
+    background-color: #0070DD;
+    color: #fff;
+}
+.temps option[value="exquisite"] {
+    background-color: #A335EE;
+    color: #fff;
+}
+.temps option[value="epic"] {
+    background-color: #FF8000;
+    color: #000;
+}
+.temps option[value="legendary"] {
+    background-color: #E5CC80;
+    color: #000;
+}
+
+/* Custom hover styling for options */
+.temps option:hover {
+    background-color: inherit;
+    text-decoration: underline;
+    text-transform: uppercase;
+}
 select#scaleSelect {
 	width: 100%;
 	margin-top: 10px;


### PR DESCRIPTION
## Summary
- Use background colors for template quality options to match material colors
- Inline quality color handling in craftparse.js so dropdown retains color after selection

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_68946a61dc8083229241c70ac221dc2b