### PR TITLE
Refine odds fallbacks and adjust UI defaults

### DIFF
--- a/craftparse.js
+++ b/craftparse.js
@@ -26,7 +26,7 @@ let requestedTemplates = {};
 let remainingUse = {};
 let ctwMediumNotice = false;
 let lowOddsNotice = false;
-let mediumOddsNotice25 = false;
+let level20OnlyWarlordsActive = false;
 
 function slug(str) {
     return (str || '')
@@ -683,7 +683,7 @@ function renderResults(templateCounts, materialCounts) {
                 itemsDiv.appendChild(levelHeader);
             }
 
-            if (lvl === 20 && ctwMediumNotice) {
+            if (lvl === 20 && ctwMediumNotice && !level20OnlyWarlordsActive) {
                 const extraInfo = document.createElement('p');
                 extraInfo.className = 'craft-extra-info';
                 extraInfo.textContent = "Medium odds items were used because otherwise no items would be generated. At level 20, Ceremonial Targaryen Warlord items are categorized as 'medium odds'.";
@@ -695,12 +695,7 @@ function renderResults(templateCounts, materialCounts) {
                 extraInfo.textContent = "Low odds items were used because otherwise no items would be generated.";
                 itemsDiv.appendChild(extraInfo);
             }
-            if (lvl === 25 && mediumOddsNotice25) {
-                const extraInfo = document.createElement('p');
-                extraInfo.className = 'craft-extra-info';
-                extraInfo.textContent = "Medium odds items were used because otherwise no items would be generated.";
-                itemsDiv.appendChild(extraInfo);
-            }
+            
 
             const levelGroup = document.createElement('div');
             levelGroup.className = 'level-group';
@@ -1046,9 +1041,9 @@ function calculateProductionPlan(availableMaterials, templatesByLevel) {
         key => (materialToSeason[key] || 0) !== 0
     );
     const level20Allowed = hasGearMaterials && allowedGearLevels.includes(20);
+    level20OnlyWarlordsActive = level20OnlyWarlords;
     ctwMediumNotice = includeWarlords && !includeMediumOdds && !level20Allowed && !level20OnlyWarlords;
     lowOddsNotice = !includeWarlords && !includeMediumOdds && !includeLowOdds;
-    mediumOddsNotice25 = !includeWarlords && !includeMediumOdds;
 
     // Craft level 15 items first when only normal odds are allowed and
     // no CTW or gear materials are in use at that level.
@@ -1114,7 +1109,7 @@ function calculateProductionPlan(availableMaterials, templatesByLevel) {
             const applyOdds = !isLegendary && (p.season === 0 || (p.level === 20 && (p.season === 1 || p.season === 2)));
             if (!applyOdds || !p.odds) return true;
             if (p.odds === 'low') return includeLowOdds || (lowOddsNotice && p.level === 20);
-            if (p.odds === 'medium') return includeMediumOdds || (ctwMediumNotice && p.warlord && p.level === 20) || (mediumOddsNotice25 && p.level === 25);
+            if (p.odds === 'medium') return includeMediumOdds || (ctwMediumNotice && p.warlord && p.level === 20);
             return true;
         });
         levelProducts = filterProductsByAvailableGear(levelProducts, availableMaterials, multiplier);
@@ -1154,7 +1149,7 @@ function calculateProductionPlan(availableMaterials, templatesByLevel) {
                 const applyOdds = !isLegendary && (p.season === 0 || (p.level === 20 && (p.season === 1 || p.season === 2)));
                 if (!applyOdds || !p.odds) return true;
                 if (p.odds === 'low') return includeLowOdds || (lowOddsNotice && p.level === 20);
-                if (p.odds === 'medium') return includeMediumOdds || (ctwMediumNotice && p.warlord && p.level === 20) || (mediumOddsNotice25 && p.level === 25);
+                if (p.odds === 'medium') return includeMediumOdds || (ctwMediumNotice && p.warlord && p.level === 20);
                 return true;
             });
             levelProducts = filterProductsByAvailableGear(levelProducts, availableMaterials, multiplier);

--- a/index.html
+++ b/index.html
@@ -174,8 +174,8 @@
                                 <select name="temp30" id="temp30" class="temps">
                                         <option value="poor">Poor</option>
                                         <option value="common">Common</option>
-                                        <option value="fine">Fine</option>
-                                        <option value="exquisite" selected>Exquisite</option>
+                                        <option value="fine" selected>Fine</option>
+                                        <option value="exquisite">Exquisite</option>
                                         <option value="epic">Epic</option>
                                         <option value="legendary">Legendary</option>
                                 </select>

--- a/style.css
+++ b/style.css
@@ -668,6 +668,11 @@ button.multiplier-btn {
     background: #d5d5d5;
 }
 
+.level-dropdown div:hover {
+    background: #ececec;
+    border-color: #c7c7c7;
+}
+
 .level-dropdown div.selected {
     background: var(--primary-color);
     color: #fff;


### PR DESCRIPTION
## Summary
- stop allowing medium odds items at level 25 when only normal odds are selected
- hide the Ceremonial Targaryen Warlord medium-odds warning when the level 20 only toggle is used and track its state for rendering
- change the level 30 default quality to Fine and add a light gray hover state to the gear material level selector

## Testing
- Manual verification

------
https://chatgpt.com/codex/tasks/task_b_68dd2aaa957083228c3b5758274f5fc0