### PR TITLE
Add materials shortage warning to crafting results

### DIFF
--- a/craftparse.js
+++ b/craftparse.js
@@ -721,6 +721,14 @@ function renderResults(templateCounts, materialCounts) {
     const materialsDiv = document.createElement('div');
     materialsDiv.className = 'materials';
 
+    const materialsShortage = failedLevels.length > 0 && failedLevels.some(level => (requestedTemplates[level] || 0) > 0);
+    if (materialsShortage) {
+        const warningBanner = document.createElement('div');
+        warningBanner.className = 'materials-warning';
+        warningBanner.innerHTML = '<strong>Materials depleted.</strong> Not every requested template could be generated with the available stock.';
+        resultsDiv.appendChild(warningBanner);
+    }
+
     Object.entries(materialCounts)
         .sort(([aName], [bName]) => {
             const seasonA = materialToSeason[aName] || 0;

--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
 	<script src="seasons/season12.js"></script>
     <script src="products.js"></script>
     <script src="materials.js"></script>
-    <script defer src="craftparse.js?v=1.112"></script>
+    <script defer src="craftparse.js?v=1.113"></script>
     <script async src="https://www.googletagmanager.com/gtag/js?id=G-3KDS4M7C1F"></script>
     <script>
 	  window.dataLayer = window.dataLayer || [];

--- a/style.css
+++ b/style.css
@@ -298,6 +298,18 @@ p.craft-extra-info {
     text-align: center;
 }
 
+.materials-warning {
+    background: #fff7e6;
+    border: 1px solid #f0c36d;
+    border-radius: 8px;
+    padding: 12px 16px;
+    margin: 0 0 16px 0;
+    color: #8a5a00;
+    font-size: 15px;
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.05);
+    text-align: center;
+}
+
 .section-title {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Summary
- show a banner above the materials list when requested templates cannot all be produced because materials ran out
- style the warning to match the calculator UI and bump the script version to load the update

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dd729a88c08322a6e5013b1e3a1724