### PR TITLE
Enable gear materials for level 30 and expand odds toggles

### DIFF
--- a/craftparse.js
+++ b/craftparse.js
@@ -1218,7 +1218,7 @@ function filterProductsByAvailableGear(products, availableMaterials, multiplier 
     });
 }
 
-const SEASONAL_ODDS_LEVELS = new Set([15, 20, 25]);
+const SEASONAL_ODDS_LEVELS = new Set([15, 20, 25, 35]);
 const EXTENDED_ODDS_LEVELS = new Set([20]);
 
 function shouldApplyOddsForProduct(product) {
@@ -1307,9 +1307,8 @@ function calculateProductionPlan(availableMaterials, templatesByLevel) {
         }
     };
 
-    // Prioritize level 30 before 15 when both meet the normal odds criteria.
-    processNormalOddsLevel(30);
-    processNormalOddsLevel(15);
+    const normalOddsPriorityLevels = [35, 30, 15];
+    normalOddsPriorityLevels.forEach(level => processNormalOddsLevel(level));
 
     LEVELS.forEach(level => {
         if (templatesByLevel[level] <= 0) return;

--- a/craftparse.js
+++ b/craftparse.js
@@ -1218,6 +1218,29 @@ function filterProductsByAvailableGear(products, availableMaterials, multiplier 
     });
 }
 
+const SEASONAL_ODDS_LEVELS = new Set([15, 20, 25]);
+const EXTENDED_ODDS_LEVELS = new Set([20]);
+
+function shouldApplyOddsForProduct(product) {
+    if (!product?.odds || product.odds === 'normal') {
+        return false;
+    }
+
+    const level = product.level;
+    const season = product.season;
+    const isCeremonialTargaryenWarlord = product.setName === 'Ceremonial Targaryen Warlord';
+
+    if ((season === 0 || isCeremonialTargaryenWarlord) && SEASONAL_ODDS_LEVELS.has(level)) {
+        return true;
+    }
+
+    if ((season === 1 || season === 2) && EXTENDED_ODDS_LEVELS.has(level)) {
+        return true;
+    }
+
+    return false;
+}
+
 function calculateProductionPlan(availableMaterials, templatesByLevel) {
     let productionPlan = { "1": [], "5": [], "10": [], "15": [], "20": [], "25": [], "30": [], "35": [], "40": [], "45": [] };
     const failed = new Set();
@@ -1254,7 +1277,7 @@ function calculateProductionPlan(availableMaterials, templatesByLevel) {
                     levelProducts = levelProducts.filter(p => p.season == 0);
                 }
                 levelProducts = levelProducts.filter(p => {
-                    const applyOdds = !isLegendary && !!p.odds;
+                    const applyOdds = !isLegendary && shouldApplyOddsForProduct(p);
                     if (!applyOdds) return true;
                     if (p.odds === 'low') return includeLowOdds;
                     if (p.odds === 'medium') return includeMediumOdds;
@@ -1309,7 +1332,7 @@ function calculateProductionPlan(availableMaterials, templatesByLevel) {
             if (requireCtwOnly && p.setName === 'Ceremonial Targaryen Warlord') {
                 return true;
             }
-            const applyOdds = !isLegendary && !!p.odds;
+            const applyOdds = !isLegendary && shouldApplyOddsForProduct(p);
             if (!applyOdds) return true;
             if (p.odds === 'low') return includeLowOdds || (lowOddsNotice && p.level === 20);
             if (p.odds === 'medium') return includeMediumOdds || (ctwMediumNotice && p.warlord && p.level === 20);
@@ -1349,7 +1372,7 @@ function calculateProductionPlan(availableMaterials, templatesByLevel) {
                 if (requireCtwOnly && p.setName === 'Ceremonial Targaryen Warlord') {
                     return true;
                 }
-                const applyOdds = !isLegendary && !!p.odds;
+                const applyOdds = !isLegendary && shouldApplyOddsForProduct(p);
                 if (!applyOdds) return true;
                 if (p.odds === 'low') return includeLowOdds || (lowOddsNotice && p.level === 20);
                 if (p.odds === 'medium') return includeMediumOdds || (ctwMediumNotice && p.warlord && p.level === 20);

--- a/craftparse.js
+++ b/craftparse.js
@@ -1245,12 +1245,21 @@ function calculateProductionPlan(availableMaterials, templatesByLevel) {
         ) {
             let remaining = templatesByLevel[level];
             const multiplier = qualityMultipliers[level] || 1;
+            const isLegendary = multiplier >= 1024;
 
             while (remaining > 0) {
                 const prefs = getUserPreferences(availableMaterials);
                 let levelProducts = craftItem.products.filter(p => p.level === level && !p.warlord);
-                levelProducts = levelProducts.filter(p => p.season == 0);
-                levelProducts = levelProducts.filter(p => !p.odds || p.odds === 'normal');
+                if (!allowedGearLevels.includes(level)) {
+                    levelProducts = levelProducts.filter(p => p.season == 0);
+                }
+                levelProducts = levelProducts.filter(p => {
+                    const applyOdds = !isLegendary && !!p.odds;
+                    if (!applyOdds) return true;
+                    if (p.odds === 'low') return includeLowOdds;
+                    if (p.odds === 'medium') return includeMediumOdds;
+                    return true;
+                });
                 levelProducts = filterProductsByAvailableGear(levelProducts, availableMaterials, multiplier);
                 const selected = selectBestAvailableProduct(
                     levelProducts,
@@ -1300,8 +1309,8 @@ function calculateProductionPlan(availableMaterials, templatesByLevel) {
             if (requireCtwOnly && p.setName === 'Ceremonial Targaryen Warlord') {
                 return true;
             }
-            const applyOdds = !isLegendary && (p.season === 0 || (p.level === 20 && (p.season === 1 || p.season === 2)));
-            if (!applyOdds || !p.odds) return true;
+            const applyOdds = !isLegendary && !!p.odds;
+            if (!applyOdds) return true;
             if (p.odds === 'low') return includeLowOdds || (lowOddsNotice && p.level === 20);
             if (p.odds === 'medium') return includeMediumOdds || (ctwMediumNotice && p.warlord && p.level === 20);
             return true;
@@ -1340,8 +1349,8 @@ function calculateProductionPlan(availableMaterials, templatesByLevel) {
                 if (requireCtwOnly && p.setName === 'Ceremonial Targaryen Warlord') {
                     return true;
                 }
-                const applyOdds = !isLegendary && (p.season === 0 || (p.level === 20 && (p.season === 1 || p.season === 2)));
-                if (!applyOdds || !p.odds) return true;
+                const applyOdds = !isLegendary && !!p.odds;
+                if (!applyOdds) return true;
                 if (p.odds === 'low') return includeLowOdds || (lowOddsNotice && p.level === 20);
                 if (p.odds === 'medium') return includeMediumOdds || (ctwMediumNotice && p.warlord && p.level === 20);
                 return true;

--- a/index.html
+++ b/index.html
@@ -257,7 +257,7 @@
                         </button></div></div>
                         <div id="oddsInfoPopup" class="info-overlay"><div class="info-content"><button class="close-popup" aria-label="Close"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512">
                                         <path d="M345 137c9.4-9.4 9.4-24.6 0-33.9s-24.6-9.4-33.9 0l-119 119L73 103c-9.4-9.4-24.6-9.4-33.9 0s-9.4 24.6 0 33.9l119 119L39 375c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l119-119L311 409c9.4 9.4 24.6 9.4 33.9 0s9.4-24.6 0-33.9l-119-119L345 137z"></path>
-                               </svg></button><p><b>Odds</b>: Items are grouped into three tiers. Normal odds are always active, while medium and low odds can be toggled on or off. Odds apply to Season 0 and Ceremonial Targaryen Warlord items at levels 15, 20, and 25. Season 1 and Season 2 items are affected only at level 20.</p></div></div>
+                               </svg></button><p><b>Odds</b>: Items are grouped into three tiers. Normal odds are always active, while medium and low odds can be toggled on or off. Odds apply to Season 0 and Ceremonial Targaryen Warlord items at levels 15, 20, 25, and 35. Season 1 and Season 2 items are affected only at level 20.</p></div></div>
                         <div class="warlord-toggle checkbox-wrapper-30">
                             <span class="checkbox">
                                 <input type="checkbox" id="includeLowOdds">

--- a/index.html
+++ b/index.html
@@ -257,7 +257,7 @@
                         </button></div></div>
                         <div id="oddsInfoPopup" class="info-overlay"><div class="info-content"><button class="close-popup" aria-label="Close"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512">
                                         <path d="M345 137c9.4-9.4 9.4-24.6 0-33.9s-24.6-9.4-33.9 0l-119 119L73 103c-9.4-9.4-24.6-9.4-33.9 0s-9.4 24.6 0 33.9l119 119L39 375c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l119-119L311 409c9.4 9.4 24.6 9.4 33.9 0s9.4-24.6 0-33.9l-119-119L345 137z"></path>
-                               </svg></button><p><b>Odds</b>: Items are grouped into three tiers. Normal odds are always active. Enable medium odds to add both medium and normal items, and enable low odds as well to allow every odds tier at all levels.</p></div></div>
+                               </svg></button><p><b>Odds</b>: Items are grouped into three tiers. Normal odds are always active, while medium and low odds can be toggled on or off. Odds apply to Season 0 and Ceremonial Targaryen Warlord items at levels 15, 20, and 25. Season 1 and Season 2 items are affected only at level 20.</p></div></div>
                         <div class="warlord-toggle checkbox-wrapper-30">
                             <span class="checkbox">
                                 <input type="checkbox" id="includeLowOdds">

--- a/index.html
+++ b/index.html
@@ -256,8 +256,8 @@
                                 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336c-13.3 0-24 10.7-24 24s10.7 24 24 24l80 0c13.3 0 24-10.7 24-24s-10.7-24-24-24l-8 0 0-88c0-13.3-10.7-24-24-24l-48 0c-13.3 0-24 10.7-24 24s10.7 24 24 24l24 0 0 64-24 0zm40-144a32 32 0 1 0 0-64 32 32 0 1 0 0 64z"/></svg>
                         </button></div></div>
                         <div id="oddsInfoPopup" class="info-overlay"><div class="info-content"><button class="close-popup" aria-label="Close"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512">
-					<path d="M345 137c9.4-9.4 9.4-24.6 0-33.9s-24.6-9.4-33.9 0l-119 119L73 103c-9.4-9.4-24.6-9.4-33.9 0s-9.4 24.6 0 33.9l119 119L39 375c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l119-119L311 409c9.4 9.4 24.6 9.4 33.9 0s9.4-24.6 0-33.9l-119-119L345 137z"></path>
-                               </svg></button><p><b>Odds</b>: Items are grouped into three tiers. Normal odds are always active, while medium and low odds can be toggled on or off. Odds apply to Season 0 and Ceremonial Targaryen Warlord items at levels 15, 20, and 25. Season 1 and Season 2 items are affected only at level 20.</p></div></div>
+                                        <path d="M345 137c9.4-9.4 9.4-24.6 0-33.9s-24.6-9.4-33.9 0l-119 119L73 103c-9.4-9.4-24.6-9.4-33.9 0s-9.4 24.6 0 33.9l119 119L39 375c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l119-119L311 409c9.4 9.4 24.6 9.4 33.9 0s9.4-24.6 0-33.9l-119-119L345 137z"></path>
+                               </svg></button><p><b>Odds</b>: Items are grouped into three tiers. Normal odds are always active. Enable medium odds to add both medium and normal items, and enable low odds as well to allow every odds tier at all levels.</p></div></div>
                         <div class="warlord-toggle checkbox-wrapper-30">
                             <span class="checkbox">
                                 <input type="checkbox" id="includeLowOdds">


### PR DESCRIPTION
## Summary
- allow level 30 normal-odds calculations to respect gear material availability when the level is enabled
- apply medium and low odds toggles to every level and keep the UI help text in sync

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68dd7a60db1c8322889b258219fb7f9e