### PR TITLE
Fix level 30 odds filtering

### DIFF
--- a/craftparse.js
+++ b/craftparse.js
@@ -1218,7 +1218,7 @@ function filterProductsByAvailableGear(products, availableMaterials, multiplier 
     });
 }
 
-const SEASONAL_ODDS_LEVELS = new Set([15, 20, 25, 35]);
+const SEASONAL_ODDS_LEVELS = new Set([15, 20, 25, 30, 35]);
 const EXTENDED_ODDS_LEVELS = new Set([20]);
 
 function shouldApplyOddsForProduct(product) {


### PR DESCRIPTION
## Summary
- ensure level 30 products flagged with low or medium odds are excluded when those odds are disabled

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dd845997f88322b8233956136638f7