### PR TITLE
Add materials guidance info popup and update defaults

### DIFF
--- a/craftparse.js
+++ b/craftparse.js
@@ -342,6 +342,19 @@ document.addEventListener('DOMContentLoaded', function() {
         }
     });
 
+    const materialsInfoBtn = document.getElementById('yourMaterialsInfoBtn');
+    const materialsInfoPopup = document.getElementById('yourMaterialsInfoPopup');
+    materialsInfoBtn?.addEventListener('click', () => {
+        if (materialsInfoPopup) {
+            materialsInfoPopup.style.display = 'flex';
+        }
+    });
+    materialsInfoPopup?.addEventListener('click', (e) => {
+        if (e.target === materialsInfoPopup || e.target.closest('.close-popup')) {
+            materialsInfoPopup.style.display = 'none';
+        }
+    });
+
     const scaleBtn = document.getElementById('scaleInfoBtn');
     const scalePopup = document.getElementById('scaleInfoPopup');
     scaleBtn?.addEventListener('click', () => {
@@ -1769,11 +1782,12 @@ function initAdvMaterialSection() {
     select.multiple = true;
     select.style.display = 'none';
 
+    const defaultGearLevels = [25, 40, 45];
     [5,10,15,20,25,30,35,40,45].forEach(l => {
         const optionDiv = document.createElement('div');
         optionDiv.dataset.value = l;
         optionDiv.textContent = l;
-        if (![5,10,15].includes(l)) {
+        if (defaultGearLevels.includes(l)) {
             optionDiv.classList.add('selected');
         }
         dropdown.appendChild(optionDiv);
@@ -1781,7 +1795,7 @@ function initAdvMaterialSection() {
         const opt = document.createElement('option');
         opt.value = l;
         opt.textContent = l;
-        if (![5,10,15].includes(l)) {
+        if (defaultGearLevels.includes(l)) {
             opt.selected = true;
         }
         select.appendChild(opt);

--- a/index.html
+++ b/index.html
@@ -59,7 +59,10 @@
                         </select>
 
                         <div id="yourMaterials" class="material-choices">
-                                <div class="section-title"><div class="checkbox-header"><span>Your materials</span></div></div>
+                                <div class="section-title"><div class="checkbox-header"><span>Your materials</span><button id="yourMaterialsInfoBtn" class="info-btn" aria-label="Your materials info">
+                                <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336c-13.3 0-24 10.7-24 24s10.7 24 24 24l80 0c13.3 0 24-10.7 24-24s-10.7-24-24-24l-8 0 0-88c0-13.3-10.7-24-24-24l-48 0c-13.3 0-24 10.7-24 24s10.7 24 24 24l24 0 0 64-24 0zm40-144a32 32 0 1 0 0-64 32 32 0 1 0 0 64z"/></svg>
+                                </button></div></div>
+                                <div id="yourMaterialsInfoPopup" class="info-overlay"><div class="info-content"><button class="close-popup" aria-label="Close"><svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><path d="M345 137c9.4-9.4 9.4-24.6 0-33.9s-24.6-9.4-33.9 0l-119 119L73 103c-9.4-9.4-24.6-9.4-33.9 0s-9.4 24.6 0 33.9l119 119L39 375c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l119-119L311 409c9.4 9.4 24.6 9.4 33.9 0s9.4-24.6 0-33.9l-119-119L345 137z"/></svg></button><p>Enter the total amount of each material at <b>Poor</b> quality. If your inventory is in higher tiers, downgrade them in-game and use the resulting Poor total here. This ensures the calculator matches the expected material scale.</p></div></div>
                                 <div class="materials-list">
 					<div class="my-material black-iron"><img src="materials/icon_crafting_blackiron.webp"><div><span>Black Iron</span><input type="text" class="numeric-input" id="my-black-iron" name="my-black-iron" placeholder="value" pattern="[0-9]*" inputmode="numeric"></div></div>
 					<div class="my-material copper-bar"><img src="materials/icon_crafting_copper_bar.webp"><div><span>Copper bar</span><input type="text" class="numeric-input" id="my-copper-bar" name="my-copper-bar" placeholder="value" pattern="[0-9]*" inputmode="numeric"></div></div>
@@ -240,7 +243,7 @@
                         </div>
                         <div class="warlord-toggle checkbox-wrapper-30">
                             <span class="checkbox">
-                                <input type="checkbox" id="level20OnlyWarlords">
+                                <input type="checkbox" id="level20OnlyWarlords" checked>
                                 <svg><use xlink:href="#checkbox-30"></use></svg>
                             </span>
                             <label for="level20OnlyWarlords">Only for Level 20</label>


### PR DESCRIPTION
## Summary
- add an info popup to the Your materials section to clarify that inputs should be entered at Poor quality
- enable the Ceremonial Targaryen Warlord "Only for Level 20" option by default
- adjust default gear material level selections to only include levels 25, 40, and 45

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68dd8c30558c8322a282a20828e73288