### PR TITLE
Add Season 0 weighting slider and integrate scoring

### DIFF
--- a/index.html
+++ b/index.html
@@ -275,6 +275,32 @@
                             </span>
                             <label for="includeMediumOdds">Include medium odds items</label>
                         </div>
+                        <div class="season-zero-section">
+                            <div class="section-title">
+                                <div class="checkbox-header">
+                                    <span>Season 0 weighting</span>
+                                </div>
+                            </div>
+                            <div class="season-zero-slider">
+                                <div id="seasonZeroPriorityValue" class="season-zero-slider__value">Normal weighting</div>
+                                <input
+                                    type="range"
+                                    min="0"
+                                    max="3"
+                                    step="1"
+                                    value="2"
+                                    id="seasonZeroPriority"
+                                    class="season-zero-slider__input"
+                                    aria-labelledby="seasonZeroPriorityValue"
+                                >
+                                <div class="season-zero-slider__labels">
+                                    <span>Off</span>
+                                    <span>Low</span>
+                                    <span>Normal</span>
+                                    <span>High</span>
+                                </div>
+                            </div>
+                        </div>
                         <svg xmlns="http://www.w3.org/2000/svg" style="display:none">
                             <symbol id="checkbox-30" viewBox="0 0 22 22">
                                 <path fill="none" stroke="currentColor" d="M5.5,11.3L9,14.8L20.2,3.3l0,0c-0.5-1-1.5-1.8-2.7-1.8h-13c-1.7,0-3,1.3-3,3v13c0,1.7,1.3,3,3,3h13 c1.7,0,3-1.3,3-3v-13c0-0.4-0.1-0.8-0.3-1.2"/>


### PR DESCRIPTION
## Summary
- add a season 0 weighting slider to the crafting preferences view
- connect the slider state to the production plan so season 0 items can be excluded, deprioritised, or prioritised
- adjust product scoring to respect the selected season 0 weighting while keeping existing balance logic

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68e002c6f1c48322bc439f04c05e304a