### PR TITLE
Adjust Season 0 weighting controls

### DIFF
--- a/craftparse.js
+++ b/craftparse.js
@@ -34,7 +34,7 @@ const seasonZeroValueText = {
     [SeasonZeroPreference.HIGH]: 'High weighting'
 };
 const SEASON_ZERO_LOW_PENALTY = 3;
-const SEASON_ZERO_HIGH_BONUS = 5;
+const SEASON_ZERO_HIGH_BONUS = 7;
 const SEASON_ZERO_HIGH_NON_SEASON_PENALTY = 2;
 let currentSeasonZeroPreference = SeasonZeroPreference.NORMAL;
 const qualityColorMap = {
@@ -398,6 +398,19 @@ document.addEventListener('DOMContentLoaded', function() {
     gearPopup?.addEventListener('click', (e) => {
         if (e.target === gearPopup || e.target.closest('.close-popup')) {
             gearPopup.style.display = 'none';
+        }
+    });
+
+    const seasonZeroBtn = document.getElementById('seasonZeroInfoBtn');
+    const seasonZeroPopup = document.getElementById('seasonZeroInfoPopup');
+    seasonZeroBtn?.addEventListener('click', () => {
+        if (seasonZeroPopup) {
+            seasonZeroPopup.style.display = 'flex';
+        }
+    });
+    seasonZeroPopup?.addEventListener('click', (e) => {
+        if (e.target === seasonZeroPopup || e.target.closest('.close-popup')) {
+            seasonZeroPopup.style.display = 'none';
         }
     });
 
@@ -1856,7 +1869,7 @@ function initAdvMaterialSection() {
     select.multiple = true;
     select.style.display = 'none';
 
-    const defaultGearLevels = [25, 40, 45];
+    const defaultGearLevels = [20, 25, 30, 35, 40, 45];
     [5,10,15,20,25,30,35,40,45].forEach(l => {
         const optionDiv = document.createElement('div');
         optionDiv.dataset.value = l;
@@ -1889,4 +1902,9 @@ function initAdvMaterialSection() {
     levelWrap.appendChild(dropdown);
     levelWrap.appendChild(select);
     container.appendChild(levelWrap);
+
+    const seasonZeroSection = document.querySelector('.season-zero-section');
+    if (seasonZeroSection) {
+        container.appendChild(seasonZeroSection);
+    }
 }

--- a/index.html
+++ b/index.html
@@ -279,6 +279,17 @@
                             <div class="section-title">
                                 <div class="checkbox-header">
                                     <span>Season 0 weighting</span>
+                                    <button id="seasonZeroInfoBtn" class="info-btn" aria-label="Season 0 weighting info">
+                                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512"><path d="M256 48a208 208 0 1 1 0 416 208 208 0 1 1 0-416zm0 464A256 256 0 1 0 256 0a256 256 0 1 0 0 512zM216 336c-13.3 0-24 10.7-24 24s10.7 24 24 24l80 0c13.3 0 24-10.7 24-24s-10.7-24-24-24l-8 0 0-88c0-13.3-10.7-24-24-24l-48 0c-13.3 0-24 10.7-24 24s10.7 24 24 24l24 0 0 64-24 0zm40-144a32 32 0 1 0 0-64 32 32 0 1 0 0 64z"/></svg>
+                                    </button>
+                                </div>
+                            </div>
+                            <div id="seasonZeroInfoPopup" class="info-overlay">
+                                <div class="info-content">
+                                    <button class="close-popup" aria-label="Close">
+                                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 384 512"><path d="M345 137c9.4-9.4 9.4-24.6 0-33.9s-24.6-9.4-33.9 0l-119 119L73 103c-9.4-9.4-24.6-9.4-33.9 0s-9.4 24.6 0 33.9l119 119L39 375c-9.4 9.4-9.4 24.6 0 33.9s24.6 9.4 33.9 0l119-119L311 409c9.4 9.4 24.6 9.4 33.9 0s9.4-24.6 0-33.9l-119-119L345 137z"/></svg>
+                                    </button>
+                                    <p>Adjust how strongly Season 0 items are prioritized. Off excludes them, Low slightly reduces their priority, Normal keeps the default weighting, and High strongly prefers Season 0 while lowering the priority of other seasons.</p>
                                 </div>
                             </div>
                             <div class="season-zero-slider">


### PR DESCRIPTION
## Summary
- add an info dialog to the Season 0 weighting slider and relocate the control beneath the gear level selector
- expand the default gear level selections and boost the Season 0 high weighting bonus for stronger prioritisation

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e00a9331388322a34cd49a2c807bee