### PR TITLE
Improve crafting calculation performance and add progress feedback

### DIFF
--- a/index.html
+++ b/index.html
@@ -350,7 +350,7 @@
 				</script>
 			</div>
 		</div>
-		<div class="spinner-wrap"><div class="loading"><div class="spinner"><svg viewBox="25 25 50 50" class="circular"><circle stroke-miterlimit="10" stroke-width="3" fill="none" r="20" cy="50" cx="50" class="path"></circle></svg></div><p>Loading...</p></div></div>
+            <div class="spinner-wrap"><div class="loading"><div class="spinner"><svg viewBox="25 25 50 50" class="circular"><circle stroke-miterlimit="10" stroke-width="3" fill="none" r="20" cy="50" cx="50" class="path"></circle></svg></div><p>Loading...</p><div class="spinner-progress" aria-live="polite"><div class="spinner-progress__track" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0"><div class="spinner-progress__bar"></div></div><span class="spinner-progress__label">Preparing templates…</span></div></div></div>
     </div>
         
     <footer>

--- a/style.css
+++ b/style.css
@@ -988,6 +988,38 @@ button.multiplier-btn {
 .spinner p {
     text-align: center;
 }
+.spinner-progress {
+    width: 100%;
+    max-width: 320px;
+    margin: 12px auto 0;
+    opacity: 0;
+    transition: opacity 0.2s ease-in-out;
+}
+.spinner-progress.is-active {
+    opacity: 1;
+}
+.spinner-progress__track {
+    position: relative;
+    height: 6px;
+    background: rgba(0, 0, 0, 0.1);
+    border-radius: 999px;
+    overflow: hidden;
+}
+.spinner-progress__bar {
+    position: absolute;
+    inset: 0;
+    background: var(--primary-color);
+    transform: scaleX(0);
+    transform-origin: left center;
+    transition: transform 0.2s ease-in-out;
+}
+.spinner-progress__label {
+    display: block;
+    margin-top: 8px;
+    font-size: 14px;
+    text-align: center;
+    color: #08425a;
+}
 .spinner .circular {
     animation: rotate73451 2s linear infinite;
     height: 100%;


### PR DESCRIPTION
## Summary
- cache material and product lookups so repeated calculations reuse precomputed data
- make the production plan generator async with a progress tracker and show percent completion while templates are prepared
- update the loading spinner to display a styled progress bar with descriptive status text

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_b_68e013b074e883228b84ec685c689d8a