### PR TITLE
Remove spinner from loading overlay and boost Season 0 weighting

### DIFF
--- a/craftparse.js
+++ b/craftparse.js
@@ -60,8 +60,8 @@ const seasonZeroValueText = {
     [SeasonZeroPreference.HIGH]: 'High weighting'
 };
 const SEASON_ZERO_LOW_PENALTY = 3;
-const SEASON_ZERO_HIGH_BONUS = 25;
-const SEASON_ZERO_HIGH_NON_SEASON_PENALTY = 2;
+const SEASON_ZERO_HIGH_BONUS = 40;
+const SEASON_ZERO_HIGH_NON_SEASON_PENALTY = 3;
 let currentSeasonZeroPreference = SeasonZeroPreference.NORMAL;
 const qualityColorMap = {
     poor: '#A9A9A9',
@@ -466,7 +466,7 @@ document.addEventListener('DOMContentLoaded', function() {
             const data = JSON.parse(atob(shareParam));
             initialMaterials = data.initialMaterials || {};
             populateInputsFromShare(data);
-            // Show spinner before automatic calculation
+            // Show loading overlay before automatic calculation
             document.querySelector('.spinner-wrap').classList.add('active');
             // Automatically trigger calculation based on the populated inputs
             calculateMaterials();

--- a/index.html
+++ b/index.html
@@ -350,7 +350,17 @@
 				</script>
 			</div>
 		</div>
-            <div class="spinner-wrap"><div class="loading"><div class="spinner"><svg viewBox="25 25 50 50" class="circular"><circle stroke-miterlimit="10" stroke-width="3" fill="none" r="20" cy="50" cx="50" class="path"></circle></svg></div><p>Loading...</p><div class="spinner-progress" aria-live="polite"><div class="spinner-progress__track" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0"><div class="spinner-progress__bar"></div></div><span class="spinner-progress__label">Preparing templates…</span></div></div></div>
+            <div class="spinner-wrap">
+                    <div class="loading">
+                            <p class="loading-message">Preparing calculations…</p>
+                            <div class="spinner-progress" aria-live="polite">
+                                    <div class="spinner-progress__track" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0">
+                                            <div class="spinner-progress__bar"></div>
+                                    </div>
+                                    <span class="spinner-progress__label">Preparing templates…</span>
+                            </div>
+                    </div>
+            </div>
     </div>
         
     <footer>

--- a/style.css
+++ b/style.css
@@ -963,35 +963,42 @@ button.multiplier-btn {
     border-radius: 4px;
     z-index: 5;
     user-select: none;
-    margin: 0px auto;
+    margin: 0 auto;
     max-width: 600px;
     justify-content: center;
     align-items: center;
+    padding: 24px;
 }
 
 .spinner-wrap.active {
     display: flex;
 }
 
-.spinner-wrap .spinner {
-    --color: #000000;
-    position: relative;
-    width: 60px;
-    margin: 0 auto;
-}
-.spinner-wrap .spinner:before {
-    content: "";
-    display: block;
-    padding-top: 100%;
-}
-
-.spinner p {
+.spinner-wrap .loading {
+    background: #ffffff;
+    border-radius: 12px;
+    box-shadow: 0 20px 45px rgba(0, 0, 0, 0.12);
+    padding: 28px 32px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+    max-width: 360px;
     text-align: center;
 }
+
+.spinner-wrap .loading-message {
+    margin: 0;
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--primary-color);
+}
+
 .spinner-progress {
     width: 100%;
     max-width: 320px;
-    margin: 12px auto 0;
+    margin: 0 auto;
     opacity: 0;
     transition: opacity 0.2s ease-in-out;
 }
@@ -1019,25 +1026,6 @@ button.multiplier-btn {
     font-size: 14px;
     text-align: center;
     color: #08425a;
-}
-.spinner .circular {
-    animation: rotate73451 2s linear infinite;
-    height: 100%;
-    transform-origin: center center;
-    width: 100%;
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    margin: auto;
-}
-.spinner .path {
-    stroke-dasharray: 1, 200;
-    stroke-dashoffset: 0;
-    stroke: var(--primary-color);
-    animation: dash0175 1.5s ease-in-out infinite;
-    stroke-linecap: round;
 }
 .donate-header {
     width: 100%;
@@ -1107,32 +1095,10 @@ button.multiplier-btn {
     padding: 10px 0px;
 }
 
-@keyframes rotate73451 {
-  100% {
-    transform: rotate(360deg);
-  }
-}
-@keyframes dash0175 {
-  0% {
-    stroke-dasharray: 1, 200;
-    stroke-dashoffset: 0;
-  }
-
-  50% {
-    stroke-dasharray: 89, 200;
-    stroke-dashoffset: -35px;
-  }
-
-  100% {
-    stroke-dasharray: 89, 200;
-    stroke-dashoffset: -124px;
-  }
-}
-
 @keyframes blink-animation {
     0% {border: 2px solid #d52121;}
     25% {border: 2px solid var(--primary-color); }
-	50% {border: 2px solid #d52121;}
+        50% {border: 2px solid #d52121;}
 	75% {border: 2px solid var(--primary-color); }
     100% {border: 2px solid #d52121;}
 }


### PR DESCRIPTION
## Summary
- replace the spinner animation with a cleaner loading message and progress bar styling
- tweak styles for the loading overlay to center the progress indicator without the spinner
- increase the Season 0 high preference bonus and non-season penalty to emphasize that option

## Testing
- python3 -m http.server 8000 (manual)


------
https://chatgpt.com/codex/tasks/task_b_68e01a818f2083228e250c7de2245fd1