### PR TITLE
Improve Season 0 weighting slider layout

### DIFF
--- a/craftparse.js
+++ b/craftparse.js
@@ -414,10 +414,11 @@ function getSeasonZeroPreference() {
 }
 
 function updateSeasonZeroSliderLabel(value) {
-    const labelEl = document.getElementById('seasonZeroPriorityValue');
-    if (!labelEl) return;
+    const sliderEl = document.getElementById('seasonZeroPriority');
+    if (!sliderEl) return;
     const normalized = Number.isInteger(value) ? value : SeasonZeroPreference.NORMAL;
-    labelEl.textContent = seasonZeroValueText[normalized] || seasonZeroValueText[SeasonZeroPreference.NORMAL];
+    const valueText = seasonZeroValueText[normalized] || seasonZeroValueText[SeasonZeroPreference.NORMAL];
+    sliderEl.setAttribute('aria-valuetext', valueText);
 }
 
 function initializeSeasonZeroSlider() {

--- a/index.html
+++ b/index.html
@@ -293,7 +293,6 @@
                                 </div>
                             </div>
                             <div class="season-zero-slider">
-                                <div id="seasonZeroPriorityValue" class="season-zero-slider__value">Normal weighting</div>
                                 <input
                                     type="range"
                                     min="0"
@@ -302,9 +301,10 @@
                                     value="2"
                                     id="seasonZeroPriority"
                                     class="season-zero-slider__input"
-                                    aria-labelledby="seasonZeroPriorityValue"
+                                    aria-label="Season 0 weighting"
+                                    aria-describedby="seasonZeroPriorityLabels"
                                 >
-                                <div class="season-zero-slider__labels">
+                                <div class="season-zero-slider__labels" id="seasonZeroPriorityLabels">
                                     <span>Off</span>
                                     <span>Low</span>
                                     <span>Normal</span>

--- a/style.css
+++ b/style.css
@@ -888,22 +888,22 @@ button.multiplier-btn {
     margin-bottom: 20px;
 }
 
-.season-zero-slider__value {
-    text-align: center;
-    font-weight: 600;
-    color: var(--primary-color);
-}
-
 .season-zero-slider__input {
     width: 100%;
     accent-color: var(--primary-color);
+    margin: 0;
+    display: block;
 }
 
 .season-zero-slider__labels {
-    display: flex;
-    justify-content: space-between;
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
     font-size: 12px;
     color: #666;
+}
+
+.season-zero-slider__labels span {
+    text-align: center;
 }
 
 #generatebychoice h4 {


### PR DESCRIPTION
## Summary
- remove the redundant text readout above the Season 0 weighting slider and provide inline accessibility labelling instead
- update the range slider styling so the stops align with the Off/Low/Normal/High captions
- keep the existing Season 0 preference strings by exposing them via aria-valuetext on the slider

## Testing
- manual via browser

------
https://chatgpt.com/codex/tasks/task_b_68e024dd2fdc832282ead9784390afd3