### PR TITLE
Remove low-odds fallback and refresh changelog

### DIFF
--- a/craftparse.js
+++ b/craftparse.js
@@ -82,7 +82,6 @@ let failedLevels = [];
 let requestedTemplates = {};
 let remainingUse = {};
 let ctwMediumNotice = false;
-let lowOddsNotice = false;
 let level20OnlyWarlordsActive = false;
 const productsByLevel = craftItem.products.reduce((acc, product) => {
     const levelKey = product.level.toString();
@@ -1203,14 +1202,6 @@ function renderResults(templateCounts, materialCounts) {
                 extraInfo.textContent = "Medium odds items were used because otherwise no items would be generated. At level 20, Ceremonial Targaryen Warlord items are categorized as 'medium odds'.";
                 itemsDiv.appendChild(extraInfo);
             }
-            if (lvl === 20 && lowOddsNotice && !level20OnlyWarlordsActive) {
-                const extraInfo = document.createElement('p');
-                extraInfo.className = 'craft-extra-info';
-                extraInfo.textContent = "Low odds items were used because otherwise no items would be generated.";
-                itemsDiv.appendChild(extraInfo);
-            }
-            
-
             const levelGroup = document.createElement('div');
             levelGroup.className = 'level-group';
             itemsDiv.appendChild(levelGroup);
@@ -1582,7 +1573,6 @@ async function calculateProductionPlan(availableMaterials, templatesByLevel, pro
     const level20Allowed = hasGearMaterials && allowedGearLevels.includes(20);
     level20OnlyWarlordsActive = level20OnlyWarlords;
     ctwMediumNotice = includeWarlords && !includeMediumOdds && !level20Allowed && !level20OnlyWarlords;
-    lowOddsNotice = !includeWarlords && !includeMediumOdds && !includeLowOdds;
     const progress = typeof progressTick === 'function' ? progressTick : async () => {};
 
     const getLevelProducts = (level, { requireCtwOnly = false } = {}) => {
@@ -1611,7 +1601,7 @@ async function calculateProductionPlan(availableMaterials, templatesByLevel, pro
             }
             const applyOdds = !isLegendary && shouldApplyOddsForProduct(p);
             if (!applyOdds) return true;
-            if (p.odds === 'low') return includeLowOdds || (lowOddsNotice && p.level === 20);
+            if (p.odds === 'low') return includeLowOdds;
             if (p.odds === 'medium') return includeMediumOdds || (ctwMediumNotice && p.warlord && p.level === 20);
             return true;
         });

--- a/index.html
+++ b/index.html
@@ -57,8 +57,7 @@
                                 <ul>
                                         <li><strong>Levels 30&ndash;45 coverage:</strong> You can now prepare high-level templates without leaving the calculator, making late-game planning effortless.</li>
                                         <li><strong>Season 0 weighting control:</strong> Choose how much influence Season 0 items have in the recommendations with an intuitive slider.</li>
-                                        <li><strong>Smarter, faster math:</strong> Behind-the-scenes calculation optimizations mean quicker results, even for large inventories.</li>
-                                        <li><strong>Refined interface:</strong> Layout and styling tweaks improve readability and keep important actions within easy reach.</li>
+                                        <li><strong>Enhanced calculation algorithm:</strong> Behind-the-scenes logic improvements make the planner handle the expanded dataset more reliably.</li>
                                 </ul>
                         </div>
                 </div>


### PR DESCRIPTION
## Summary
- stop injecting low-odds items when those odds are disabled and rely on the existing CTW controls instead
- update the changelog entry to highlight algorithm improvements without claiming UI or speed changes

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68e0d7b7b8dc83228a10c7d89dc4550c