### PR TITLE
Fix CTW season classification

### DIFF
--- a/products.js
+++ b/products.js
@@ -1,12 +1,12 @@
 let craftItem = {
-	products: [
-		...season0.sets.flatMap(set =>
-				set.products.map(product => ({
-						...product,
-						setName: product.setName || set.setName,
-						season: season0.season
-				}))
-		),
+        products: [
+                ...season0.sets.flatMap(set =>
+                                set.products.map(product => ({
+                                                ...product,
+                                                setName: product.setName || set.setName,
+                                                season: season0.season
+                                }))
+                ),
 		...season1.sets.flatMap(set =>
 				set.products.map(product => ({
 						...product,
@@ -111,6 +111,16 @@ const seasonsMap = {
 };
 
 const extraProducts = [];
+
+const CTW_SET_NAME = 'Ceremonial Targaryen Warlord';
+const CTW_SEASON = season3.season;
+
+craftItem.products = craftItem.products.map(product => {
+  if (product.setName === CTW_SET_NAME) {
+    return { ...product, season: CTW_SEASON };
+  }
+  return product;
+});
 
 craftItem.products.forEach(product => {
   if (product.level === 25 && product.season !== 0) {


### PR DESCRIPTION
## Summary
- treat Ceremonial Targaryen Warlord items as Season 3 instead of Season 0 during product aggregation
- ensure Season 0 exclusion no longer hides CTW gear while keeping other filtering intact

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e0da0c83e8832286f90d8c3ecc9aea