### PR TITLE
Prevent season 0 slider from penalizing CTW items

### DIFF
--- a/craftparse.js
+++ b/craftparse.js
@@ -48,6 +48,8 @@ const GEAR_BASELINE_BONUS = BASE_MOST_WEIGHT;
 const LEFTOVER_WEIGHT_BASE = 7;
 const LEFTOVER_WEIGHT_GEAR = 3;
 const BALANCE_WEIGHT = 0.1;
+const CTW_SET_NAME = 'Ceremonial Targaryen Warlord';
+
 const SeasonZeroPreference = Object.freeze({
     OFF: 0,
     LOW: 1,
@@ -1907,7 +1909,7 @@ function getMaterialScore(product, mostAvailableMaterials, secondMostAvailableMa
 
     if (product.season === 0) {
         score += seasonZeroAdjustment;
-    } else {
+    } else if (product.setName !== CTW_SET_NAME) {
         score += nonSeasonAdjustment;
     }
 


### PR DESCRIPTION
## Summary
- define the Ceremonial Targaryen Warlord set name so it can be recognized during scoring
- ensure season 0 weighting adjustments do not penalize CTW items, keeping the slider focused on true season 0 gear

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68e0e7e0fd0483229375b0cd2c8ba74e