### PR TITLE
Fix CTW constant scope conflict

### DIFF
--- a/craftparse.js
+++ b/craftparse.js
@@ -48,7 +48,11 @@ const GEAR_BASELINE_BONUS = BASE_MOST_WEIGHT;
 const LEFTOVER_WEIGHT_BASE = 7;
 const LEFTOVER_WEIGHT_GEAR = 3;
 const BALANCE_WEIGHT = 0.1;
-const CTW_SET_NAME = 'Ceremonial Targaryen Warlord';
+const CTW_SET_NAME_FALLBACK = 'Ceremonial Targaryen Warlord';
+const ctwSetName =
+    typeof window !== 'undefined' && window.CTW_SET_NAME
+        ? window.CTW_SET_NAME
+        : CTW_SET_NAME_FALLBACK;
 
 const SeasonZeroPreference = Object.freeze({
     OFF: 0,
@@ -1909,7 +1913,7 @@ function getMaterialScore(product, mostAvailableMaterials, secondMostAvailableMa
 
     if (product.season === 0) {
         score += seasonZeroAdjustment;
-    } else if (product.setName !== CTW_SET_NAME) {
+    } else if (product.setName !== ctwSetName) {
         score += nonSeasonAdjustment;
     }
 

--- a/products.js
+++ b/products.js
@@ -115,6 +115,10 @@ const extraProducts = [];
 const CTW_SET_NAME = 'Ceremonial Targaryen Warlord';
 const CTW_SEASON = season3.season;
 
+if (typeof window !== 'undefined') {
+  window.CTW_SET_NAME = CTW_SET_NAME;
+}
+
 craftItem.products = craftItem.products.map(product => {
   if (product.setName === CTW_SET_NAME) {
     return { ...product, season: CTW_SEASON };


### PR DESCRIPTION
## Summary
- avoid redeclaring the Ceremonial Targaryen Warlord constant inside craft parsing logic
- expose the CTW set name from the products module for reuse
- use the shared constant when scoring products

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e0e933299c8322b7553af2005c6bd9