### PR TITLE
Adjust CTW weighting with Season 0 slider

### DIFF
--- a/craftparse.js
+++ b/craftparse.js
@@ -1913,7 +1913,7 @@ function getMaterialScore(product, mostAvailableMaterials, secondMostAvailableMa
 
     if (product.season === 0) {
         score += seasonZeroAdjustment;
-    } else if (product.setName !== ctwSetName) {
+    } else {
         score += nonSeasonAdjustment;
     }
 


### PR DESCRIPTION
## Summary
- ensure Ceremonial Targaryen Warlord items receive the same non-season score adjustment as other sets when changing the Season 0 weighting slider

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e0ea9d6b54832298a921c98348d6e8