### PR TITLE
Move CTW items into separate dataset

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,9 +14,10 @@
     <link rel="stylesheet" href="style.css?v=1.115">
 	<script src="seasons/season0.js"></script>
 	<script src="seasons/season1.js"></script>
-	<script src="seasons/season2.js"></script>
-	<script src="seasons/season3.js"></script>
-	<script src="seasons/season4.js"></script>
+        <script src="seasons/season2.js"></script>
+        <script src="seasons/season3.js"></script>
+        <script src="seasons/seasonctw.js"></script>
+        <script src="seasons/season4.js"></script>
 	<script src="seasons/season5.js"></script>
 	<script src="seasons/season6.js"></script>
 	<script src="seasons/season7.js"></script>

--- a/products.js
+++ b/products.js
@@ -21,18 +21,25 @@ let craftItem = {
 						season: season2.season
 				}))
 		),
-		...season3.sets.flatMap(set =>
-				set.products.map(product => ({
-						...product,
-						setName: product.setName || set.setName,
-						season: season3.season
-				}))
-		),
-		...season4.sets.flatMap(set =>
-				set.products.map(product => ({
-						...product,
-						setName: product.setName || set.setName,
-						season: season4.season
+                ...season3.sets.flatMap(set =>
+                                set.products.map(product => ({
+                                                ...product,
+                                                setName: product.setName || set.setName,
+                                                season: season3.season
+                                }))
+                ),
+                ...seasonctw.sets.flatMap(set =>
+                                set.products.map(product => ({
+                                                ...product,
+                                                setName: product.setName || set.setName,
+                                                season: seasonctw.season
+                                }))
+                ),
+                ...season4.sets.flatMap(set =>
+                                set.products.map(product => ({
+                                                ...product,
+                                                setName: product.setName || set.setName,
+                                                season: season4.season
 				}))
 		),
 		...season5.sets.flatMap(set =>

--- a/seasons/season0.js
+++ b/seasons/season0.js
@@ -1,1556 +1,1608 @@
 const season0 = {
-	season: 0,
-	sets: [
-		{
-			products: [
-				{
-					"name": "Wooden Bucket",
-					"level": 1,
-					"materials": {"weirwood": 10, "kingswood-oak": 10},
-					"img": "item/icon_eq_standard_helmet_woodenbucket.webp"
-				},
-				{
-					"name": "Leather Vest",
-					"level": 1,
-					"materials": {"hide": 10, "leather-straps": 10},
-					"img": "item/icon_eq_standard_chest_leathervest.webp"
-				},
-				{
-					"name": "Flax Legwraps",
-					"level": 1,
-					"materials": {"milk-of-the-poppy": 10, "goldenheart-wood": 10},
-					"img": "item/icon_eq_standard_pants_flaxlegwraps.webp"
-				},
-				{
-					"name": "Straw Sandals",
-					"level": 1,
-					"materials": {"hide": 10, "leather-straps": 10},
-					"img": "item/icon_eq_standard_boots_strawsandals.webp"
-				},
-				{
-					"name": "Copper Band",
-					"level": 1,
-					"materials": {"black-iron": 10, "copper-bar": 10},
-					"img": "item/icon_eq_standard_ring_copperband.webp"
-				},
-				{
-					"name": "Dagger",
-					"level": 1,
-					"materials": {"ironwood": 10, "kingswood-oak": 10},
-					"img": "item/icon_eq_standard_weapon_dagger.png"
-				},
-				{
-					"name": "Helm",
-					"level": 1,
-					"materials": {"silk": 6, "black-iron": 6, "copper-bar": 6},
-					"img": "item/ctw-head.png",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Chestplate",
-					"level": 1,
-					"materials": {"milk-of-the-poppy": 6, "hide": 6, "ironwood": 6},
-					"img": "item/ctw-chest.png",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Pants",
-					"level": 1,
-					"materials": {"kingswood-oak": 6, "wildfire": 6, "hide": 6},
-					"img": "item/ctw-pants.png",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Sword",
-					"level": 1,
-					"materials": {"ironwood": 6, "goldenheart-wood": 6, "wildfire": 6},
-					"img": "item/ctw-weapon.png",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Ring",
-					"level": 1,
-					"materials": {"weirwood": 6, "leather-straps": 6, "black-iron": 6},
-					"img": "item/ctw-ring.png",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Boots",
-					"level": 1,
-					"materials": {"ironwood": 6, "goldenheart-wood": 6, "wildfire": 6},
-					"img": "item/ctw-boots.png",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Wool Bandana",
-					"level": 5,
-					"materials": {"kingswood-oak": 15, "milk-of-the-poppy": 15},
-					"img": "item/icon_eq_standard_helmet_woolbandana.webp"
-				},
-				{
-					"name": "Boiled Leather Shirt",
-					"level": 5,
-					"materials": {"hide": 15, "dragonglass": 15},
-					"img": "item/icon_eq_standard_chest_boiledleathershirt.webp"
-				},
-				{
-					"name": "Leather Poleyns",
-					"level": 5,
-					"materials": {"hide": 15, "leather-straps": 15},
-					"img": "item/icon_eq_standard_pants_leatherpoleyns.webp"
-				},
-				{
-					"name": "Leather Booties",
-					"level": 5,
-					"materials": {"hide": 10, "silk": 10, "weirwood": 10},
-					"img": "item/icon_eq_standard_boots_leatherbooties.webp"
-				},
-				{
-					"name": "Bronze Band",
-					"level": 5,
-					"materials": {"copper-bar": 15, "milk-of-the-poppy": 15},
-					"img": "item/icon_eq_standard_ring_bronzeband.webp"
-				},
-				{
-					"name": "Spear",
-					"level": 5,
-					"materials": {"leather-straps": 15, "wildfire": 15},
-					"img": "item/icon_eq_standard_weapon_spear.webp"
-				},	
-				{
-					"name": "Helm",
-					"level": 5,
-					"materials": {"kingswood-oak": 10, "wildfire": 10, "hide": 10},
-					"img": "item/ctw-head.png",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Chestplate",
-					"level": 5,
-					"materials": {"silk": 10, "black-iron": 10, "copper-bar": 10},
-					"img": "item/ctw-chest.png",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Pants",
-					"level": 5,
-					"materials": {"weirwood": 10, "leather-straps": 10, "black-iron": 10},
-					"img": "item/ctw-pants.png",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Sword",
-					"level": 5,
-					"materials": {"copper-bar": 10, "dragonglass": 10, "leather-straps": 10},
-					"img": "item/ctw-weapon.png",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Ring",
-					"level": 5,
-					"materials": {"ironwood": 10, "goldenheart-wood": 10, "wildfire": 10},
-					"img": "item/ctw-ring.png",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Boots",
-					"level": 5,
-					"materials": {"milk-of-the-poppy": 10, "hide": 10, "ironwood": 10},
-					"img": "item/ctw-boots.png",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Copper Pot",
-					"level": 10,
-					"materials": {"copper-bar": 30, "leather-straps": 30},
-					"img": "item/icon_eq_standard_helmet_copperpot.webp"
-				},
-				{
-					"name": "Straw hat",
-					"level": 10,
-					"materials": {"dragonglass": 20, "silk": 20, "leather-straps": 20},
-					"img": "item/icon_eq_standard_helmet_strawhat.webp"
-				},
-				{
-					"name": "Wool Robe",
-					"level": 10,
-					"materials": {"milk-of-the-poppy": 30, "hide": 30},
-					"img": "item/icon_eq_standard_chest_woolrobe.webp"
-				},
-				{
-					"name": "Padded Armor",
-					"level": 10,
-					"materials": {"silk": 30, "ironwood": 30},
-					"img": "item/icon_eq_standard_chest_paddedarmor.webp"
-				},
-				{
-					"name": "Wool Leggings",
-					"level": 10,
-					"materials": {"hide": 30, "wildfire": 30},
-					"img": "item/icon_eq_standard_pants_woolleggings.webp"
-				},
-				{
-					"name": "Ragged Shorts",
-					"level": 10,
-					"materials": {"leather-straps": 30, "milk-of-the-poppy": 30},
-					"img": "item/icon_eq_standard_pants_raggedshorts.webp"
-				},
-				{
-					"name": "Velvet Boots",
-					"level": 10,
-					"materials": {"silk": 30, "wildfire": 30},
-					"img": "item/icon_eq_standard_boots_velvetboots.webp"
-				},
-				{
-					"name": "Galoshes",
-					"level": 10,
-					"materials": {"weirwood": 30, "ironwood": 30},
-					"img": "item/icon_eq_standard_boots_galoshes.webp"
-				},
-				{
-					"name": "Pyrite Lament",
-					"level": 10,
-					"materials": {"dragonglass": 30, "kingswood-oak": 30},
-					"img": "item/icon_eq_standard_ring_pyritelament.webp"
-				},
-				{
-					"name": "Quartz Ring",
-					"level": 10,
-					"materials": {"dragonglass": 30, "weirwood": 30},
-					"img": "item/icon_eq_standard_ring_quartzring.webp"
-				},
-				{
-					"name": "Mace",
-					"level": 10,
-					"materials": {"weirwood": 30, "black-iron": 30},
-					"img": "item/icon_eq_standard_weapon_mace.webp"
-				},
-				{
-					"name": "Short Bow",
-					"level": 10,
-					"materials": {"silk": 30, "goldenheart-wood": 30},
-					"img": "item/icon_eq_standard_weapon_shortbow.webp"
-				},
-{
-					"name": "Helm",
-					"level": 10,
-					"materials": {"kingswood-oak": 20, "wildfire": 20, "hide": 20},
-					"img": "item/ctw-head.png",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Chestplate",
-					"level": 10,
-					"materials": {"silk": 20, "black-iron": 20, "copper-bar": 20},
-					"img": "item/ctw-chest.png",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Pants",
-					"level": 10,
-					"materials": {"weirwood": 20, "leather-straps": 20, "black-iron": 20},
-					"img": "item/ctw-pants.png",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Sword",
-					"level": 10,
-					"materials": {"copper-bar": 20, "dragonglass": 20, "leather-straps": 20},
-					"img": "item/ctw-weapon.png",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Ring",
-					"level": 10,
-					"materials": {"ironwood": 20, "goldenheart-wood": 20, "wildfire": 20},
-					"img": "item/ctw-ring.png",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Boots",
-					"level": 10,
-					"materials": {"milk-of-the-poppy": 20, "hide": 20, "ironwood": 20},
-					"img": "item/ctw-boots.png",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Iron Skullcap",
-					"level": 15,
-					"materials": {"black-iron": 180, "leather-straps": 180},
-					"odds": "medium",
-					"img": "item/15-25/icon_eq_standard_helmet_ironskullcap.png"
-				},
-				{
-					"name": "Steel Gorget",
-					"level": 15,
-					"materials": {"black-iron": 180, "milk-of-the-poppy": 180},
-					"odds": "medium",
-					"img": "item/15-25/icon_eq_standard_helmet_steelgorget.png"
-				},
-				{
-					"name": "Mushroom Cap",
-					"level": 15,
-					"materials": {"wildfire": 180, "weirwood": 180},
-					"odds": "medium",
-					"img": "item/15-25/icon_eq_standard_helmet_mushroomcap.png"
-				},
-				{
-					"name": "Lab Smock",
-					"level": 15,
-					"materials": {"wildfire": 180, "silk": 180},
-					"odds": "medium",
-					"img": "item/15-25/icon_eq_standard_chest_labsmock.png"
-				},
-				{
-					"name": "Bronze Chain Shirt",
-					"level": 15,
-					"materials": {"copper-bar": 180, "hide": 180},
-					"odds": "medium",
-					"img": "item/15-25/icon_eq_standard_chest_bronzechainshirt.png"
-				},
-				{
-					"name": "Charred Leathers",
-					"level": 15,
-					"materials": {"leather-straps": 180, "wildfire": 180},
-					"odds": "medium",
-					"img": "item/15-25/icon_eq_standard_chest_charredleathers.png"
-				},
-				{
-					"name": "Leather Schynbalds",
-					"level": 15,
-					"materials": {"leather-straps": 180, "ironwood": 180},
-					"odds": "medium",
-					"img": "item/15-25/icon_eq_standard_pants_leatherschynbalds.png"
-				},
-				{
-					"name": "Leather Kilt",
-					"level": 15,
-					"materials": {"hide": 180, "kingswood-oak": 180},
-					"odds": "medium",
-					"img": "item/15-25/icon_eq_standard_pants_leatherkilt.png"
-				},
-				{
-					"name": "Copper Culet",
-					"level": 15,
-					"materials": {"copper-bar": 180, "wildfire": 180},
-					"odds": "medium",
-					"img": "item/15-25/icon_eq_standard_pants_copperculet.png"
-				},
-				{
-					"name": "Well-Heeled Shoes",
-					"level": 15,
-					"materials": {"weirwood": 120, "silk": 120, "dragonglass": 120},
-					"odds": "normal",
-					"img": "item/15-25/icon_eq_standard_boots_well-heeledshoes.png"
-				},
-				{
-					"name": "Steel-Toed Stompers",
-					"level": 15,
-					"materials": {"black-iron": 120, "goldenheart-wood": 120, "weirwood": 120},
-					"odds": "normal",
-					"img": "item/15-25/icon_eq_standard_boots_steel-toedstompers.png"
-				},
-				{
-					"name": "Riding Boots",
-					"level": 15,
-					"materials": {"leather-straps": 180, "kingswood-oak": 180},
-					"odds": "medium",
-					"img": "item/15-25/icon_eq_standard_boots_ridingboots.png"
-				},
-				{
-					"name": "Amethyst Embrace",
-					"level": 15,
-					"materials": {"dragonglass": 180, "silk": 180},
-					"odds": "medium",
-					"img": "item/15-25/icon_eq_standard_ring_amethystembrace.png"
-				},
-				{
-					"name": "Tiger's Eye Ring",
-					"level": 15,
-					"materials": {"dragonglass": 180, "kingswood-oak": 180},
-					"odds": "medium",
-					"img": "item/15-25/icon_eq_standard_ring_tigerseye.png"
-				},
-				{
-					"name": "Silver Band",
-					"level": 15,
-					"materials": {"ironwood": 180, "milk-of-the-poppy": 180},
-					"odds": "medium",
-					"img": "item/15-25/icon_eq_standard_ring_silverband.png"
-				},
-				{
-					"name": "Flatbow",
-					"level": 15,
-					"materials": {"goldenheart-wood": 180, "milk-of-the-poppy": 180},
-					"odds": "medium",
-					"img": "item/15-25/icon_eq_standard_weapon_flatbow.png"
-				},
-				{
-					"name": "Pike",
-					"level": 15,
-					"materials": {"goldenheart-wood": 180, "hide": 180},
-					"odds": "medium",
-					"img": "item/15-25/icon_eq_standard_weapon_pike.png"
-				},
-				{
-					"name": "Short Sword",
-					"level": 15,
-					"materials": {"ironwood": 180, "copper-bar": 180},
-					"odds": "medium",
-					"img": "item/15-25/icon_eq_standard_weapon_shortsword.png"
-				},
-				{
-					"name": "Helm",
-					"level": 15,
-					"materials": {"kingswood-oak": 120, "wildfire": 120, "hide": 120},
-					"img": "item/ctw-head.png",
-					"odds": "normal",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Chestplate",
-					"level": 15,
-					"materials": {"silk": 120, "black-iron": 120, "copper-bar": 120},
-					"img": "item/ctw-chest.png",
-					"odds": "normal",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Pants",
-					"level": 15,
-					"materials": {"weirwood": 120, "leather-straps": 120, "black-iron": 120},
-					"img": "item/ctw-pants.png",
-					"odds": "normal",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Sword",
-					"level": 15,
-					"materials": {"copper-bar": 120, "dragonglass": 120, "leather-straps": 120},
-					"img": "item/ctw-weapon.png",
-					"odds": "normal",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Ring",
-					"level": 15,
-					"materials": {"ironwood": 120, "goldenheart-wood": 120, "wildfire": 120},
-					"img": "item/ctw-ring.png",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Boots",
-					"level": 15,
-					"materials": {"milk-of-the-poppy": 120, "hide": 120, "ironwood": 120},
-					"img": "item/ctw-boots.png",
-					"odds": "normal",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Halfhelm",
-					"level": 20,
-					"materials": {"copper-bar": 600, "ironwood": 600},
-					"img": "item/15-25/icon_eq_standard_helmet_halfhelm.png",
-					"odds": "low"
-				},
-				{
-					"name": "Turban",
-					"level": 20,
-					"materials": {"silk": 600, "leather-straps": 600},
-					"img": "item/15-25/icon_eq_standard_helmet_turban.png",
-					"odds": "low"
-				},
-				{
-					"name": "Wool Coif",
-					"level": 20,
-					"materials": {"hide": 600, "wildfire": 600},
-					"img": "item/15-25/icon_eq_standard_helmet_woolcoif.png",
-					"odds": "low"
-				},
-				{
-					"name": "Merchant's Doublet",
-					"level": 20,
-					"materials": {"silk": 600, "dragonglass": 600},
-					"img": "item/15-25/icon_eq_standard_chest_merchantsdoublet.png",
-					"odds": "low"
-				},
-				{
-					"name": "Copper Chain Shirt",
-					"level": 20,
-					"materials": {"copper-bar": 600, "leather-straps": 600},
-					"img": "item/15-25/icon_eq_standard_chest_copperchainshirt.png",
-					"odds": "low"
-				},
-				{
-					"name": "Iron Chain Shirt",
-					"level": 20,
-					"materials": {"black-iron": 600, "leather-straps": 600},
-					"img": "item/15-25/icon_eq_standard_chest_ironchainshirt.png",
-					"odds": "low"
-				},
-				{
-					"name": "Wool Skirt",
-					"level": 20,
-					"materials": {"hide": 600, "leather-straps": 600},
-					"img": "item/15-25/icon_eq_standard_pants_woolskirt.png",
-					"odds": "low"
-				},
-				{
-					"name": "Leather Chaps",
-					"level": 20,
-					"materials": {"leather-straps": 600, "goldenheart-wood": 600},
-					"img": "item/15-25/icon_eq_standard_pants_leatherchaps.png",
-					"odds": "low"
-				},
-				{
-					"name": "Wooden Poleyns",
-					"level": 20,
-					"materials": {"goldenheart-wood": 600, "kingswood-oak": 600},
-					"img": "item/15-25/icon_eq_standard_pants_woodenpoleyns.png",
-					"odds": "low"
-				},
-				{
-					"name": "Boots of War",
-					"level": 20,
-					"materials": {"weirwood": 600, "ironwood": 600},
-					"img": "item/15-25/icon_eq_standard_boots_bootsofwar.png",
-					"odds": "low"
-				},
-				{
-					"name": "Sandstompers",
-					"level": 20,
-					"materials": {"leather-straps": 600, "dragonglass": 600},
-					"img": "item/15-25/icon_eq_standard_boots_sandstompers.png",
-					"odds": "low"
-				},
-				{
-					"name": "Trail Rider's Gaiters",
-					"level": 20,
-					"materials": {"hide": 600, "leather-straps": 600},
-					"img": "item/15-25/icon_eq_standard_boots_trailridersgaiters.png",
-					"odds": "low"
-				},
-				{
-					"name": "Episcopal Ring",
-					"level": 20,
-					"materials": {"milk-of-the-poppy": 600, "silk": 600},
-					"img": "item/15-25/icon_eq_standard_ring_episcopalring.png",
-					"odds": "low"
-				},
-				{
-					"name": "Mourning Ring",
-					"level": 20,
-					"materials": {"dragonglass": 600, "ironwood": 600},
-					"img": "item/15-25/icon_eq_standard_ring_mourningring.png",
-					"odds": "low"
-				},
-				{
-					"name": "Steel Band",
-					"level": 20,
-					"materials": {"black-iron": 600, "leather-straps": 600},
-					"img": "item/15-25/icon_eq_standard_ring_steelband.png",
-					"odds": "low"
-				},
-				{
-					"name": "Net",
-					"level": 20,
-					"materials": {"leather-straps": 600, "silk": 600},
-					"img": "item/15-25/icon_eq_standard_weapon_net.png",
-					"odds": "low"
-				},
-				{
-					"name": "Flail",
-					"level": 20,
-					"materials": {"hide": 600, "kingswood-oak": 600},
-					"img": "item/15-25/icon_eq_standard_weapon_flail.png",
-					"odds": "low"
-				},
-				{
-					"name": "Rapier",
-					"level": 20,
-					"materials": {"black-iron": 600, "wildfire": 600},
-					"img": "item/15-25/icon_eq_standard_weapon_rapier.png",
-					"odds": "low"
-				},		
-				{
-					"name": "Helm",
-					"level": 20,
-					"materials": {"kingswood-oak": 400, "wildfire": 400, "hide": 400},
-					"img": "item/ctw-head.png",
-					"odds": "medium",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Chestplate",
-					"level": 20,
-					"materials": {"silk": 400, "black-iron": 400, "copper-bar": 400},
-					"img": "item/ctw-chest.png",
-					"odds": "medium",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Pants",
-					"level": 20,
-					"materials": {"weirwood": 400, "leather-straps": 400, "black-iron": 400},
-					"img": "item/ctw-pants.png",
-					"odds": "medium",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Sword",
-					"level": 20,
-					"materials": {"copper-bar": 400, "dragonglass": 400, "leather-straps": 400},
-					"img": "item/ctw-weapon.png",
-					"odds": "medium",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Ring",
-					"level": 20,
-					"materials": {"ironwood": 400, "goldenheart-wood": 400, "wildfire": 400},
-					"img": "item/ctw-ring.png",
-					"odds": "medium",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Boots",
-					"level": 20,
-					"materials": {"milk-of-the-poppy": 400, "hide": 400, "ironwood": 400},
-					"img": "item/ctw-boots.png",
-					"odds": "medium",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Pirate Tricorne",
-					"level": 25,
-					"materials": {"hide": 1600, "leather-straps": 1600, "silk": 1600},
-					"img": "item/15-25/icon_eq_standard_helmet_piratetricorne.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Lead Circlet",
-					"level": 25,
-					"materials": {"black-iron": 1600, "ironwood": 1600, "dragonglass": 1600},
-					"img": "item/15-25/icon_eq_standard_helmet_leadcirclet.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Traveler's Hood",
-					"level": 25,
-					"materials": {"hide": 1600, "milk-of-the-poppy": 1600, "goldenheart-wood": 1600},
-					"img": "item/15-25/icon_eq_standard_helmet_travelershood.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Maester's Robes",
-					"level": 25,
-					"materials": {"milk-of-the-poppy": 2400, "silk": 2400},
-					"img": "item/15-25/icon_eq_standard_chest_maestersrobes.png",
-					"odds": "low",
-				},
-				{
-					"name": "Iron Chainmail",
-					"level": 25,
-					"materials": {"leather-straps": 1600, "black-iron": 1600, "hide": 1600},
-					"img": "item/15-25/icon_eq_standard_chest_ironchainmail.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Riveted Brigandine",
-					"level": 25,
-					"materials": {"weirwood": 1600, "copper-bar": 1600, "dragonglass": 1600},
-					"img": "item/15-25/icon_eq_standard_chest_rivetedbrigandine.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Bronze Chausses",
-					"level": 25,
-					"materials": {"copper-bar": 1600, "weirwood": 1600, "ironwood": 1600},
-					"img": "item/15-25/icon_eq_standard_pants_bronzechausses.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Golden Fauld",
-					"level": 25,
-					"materials": {"copper-bar": 1600, "silk": 1600, "kingswood-oak": 1600},
-					"img": "item/15-25/icon_eq_standard_pants_goldenfauld.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Tyroshi Leggings",
-					"level": 25,
-					"materials": {"milk-of-the-poppy": 1600, "wildfire": 1600, "dragonglass": 1600},
-					"img": "item/15-25/icon_eq_standard_pants_tyroshileggings.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Dancing Shoes",
-					"level": 25,
-					"materials": {"milk-of-the-poppy": 1600, "kingswood-oak": 1600, "goldenheart-wood": 1600},
-					"img": "item/15-25/icon_eq_standard_boots_dancingshoes.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Electrum Sabatons",
-					"level": 25,
-					"materials": {"black-iron": 1600, "copper-bar": 1600, "leather-straps": 1600},
-					"img": "item/15-25/icon_eq_standard_boots_electrumsabatons.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Knife-Toed Boots",
-					"level": 25,
-					"materials": {"leather-straps": 2400, "copper-bar": 2400},
-					"img": "item/15-25/icon_eq_standard_boots_knifetoedboots.png",
-					"odds": "low",
-				},
-				{
-					"name": "Painite Ring",
-					"level": 25,
-					"materials": {"dragonglass": 1600, "leather-straps": 1600, "goldenheart-wood": 1600},
-					"img": "item/15-25/icon_eq_standard_ring_painite.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Opal Ring",
-					"level": 25,
-					"materials": {"dragonglass": 1600, "kingswood-oak": 1600, "silk": 1600},
-					"img": "item/15-25/icon_eq_standard_ring_opal.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Electrum Band",
-					"level": 25,
-					"materials": {"copper-bar": 1600, "weirwood": 1600, "ironwood": 1600},
-					"img": "item/15-25/icon_eq_standard_ring_electrumband.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Light Crossbow",
-					"level": 25,
-					"materials": {"weirwood": 1600, "silk": 1600, "ironwood": 1600},
-					"img": "item/15-25/icon_eq_standard_weapon_lightcrossbow.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Hand Axe",
-					"level": 25,
-					"materials": {"leather-straps": 1600, "black-iron": 1600, "hide": 1600},
-					"img": "item/15-25/icon_eq_standard_weapon_handaxe.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Gladius",
-					"level": 25,
-					"materials": {"weirwood": 1600, "black-iron": 1600, "dragonglass": 1600},
-					"img": "item/15-25/icon_eq_standard_weapon_gladius.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Helm",
-					"level": 25,
-					"materials": {"kingswood-oak": 1200, "wildfire": 1200, "hide": 1200, "milk-of-the-poppy": 1200},
-					"img": "item/ctw-head.png",
-					"odds": "normal",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Chestplate",
-					"level": 25,
-					"materials": {"silk": 1200, "black-iron": 1200, "copper-bar": 1200, "dragonglass": 1200},
-					"img": "item/ctw-chest.png",
-					"odds": "normal",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Pants",
-					"level": 25,
-					"materials": {"weirwood": 1200, "leather-straps": 1200, "black-iron": 1200, "silk": 1200},
-					"img": "item/ctw-pants.png",
-					"odds": "normal",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Sword",
-					"level": 25,
-					"materials": {"copper-bar": 1200, "dragonglass": 1200, "leather-straps": 1200, "weirwood": 1200},
-					"img": "item/ctw-weapon.png",
-					"odds": "normal",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Ring",
-					"level": 25,
-					"materials": {"ironwood": 1200, "goldenheart-wood": 1200, "wildfire": 1200, "kingswood-oak": 1200},
-					"img": "item/ctw-ring.png",
-					"odds": "normal",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Boots",
-					"level": 25,
-					"materials": {"milk-of-the-poppy": 1200, "hide": 1200, "ironwood": 1200, "goldenheart-wood": 1200},
-					"img": "item/ctw-boots.png",
-					"odds": "normal",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Kettle Helm",
-					"level": 30,
-					"materials": {"copper-bar": 6000, "goldenheart-wood": 6000},
-					"img": "item/30-45/icon_eq_standard_helmet_kettlehelm.png",
-					"odds": "low",
-				},
-				{
-					"name": "Garnet Forehead Pendant",
-					"level": 30,
-					"materials": {"dragonglass": 4000, "leather-straps": 4000, "wildfire": 4000},
-					"img": "item/30-45/icon_eq_standard_helmet_garnetforeheadpendant.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Officer's Plumed Helm",
-					"level": 30,
-					"materials": {"silk": 4000, "dragonglass": 4000, "hide": 4000},
-					"img": "item/30-45/icon_eq_standard_helmet_officersplumedhelm.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Silk Tunic",
-					"level": 30,
-					"materials": {"silk": 6000, "milk-of-the-poppy": 6000},
-					"img": "item/30-45/icon_eq_standard_chest_silktunic.png",
-					"odds": "low",
-				},
-				{
-					"name": "Gold Chainmail",
-					"level": 30,
-					"materials": {"leather-straps": 6000, "copper-bar": 6000},
-					"img": "item/30-45/icon_eq_standard_chest_goldchainmail.png",
-					"odds": "low",
-				},
-				{
-					"name": "Iron Brigandine",
-					"level": 30,
-					"materials": {"weirwood": 4000, "leather-straps": 4000, "hide": 4000},
-					"img": "item/30-45/icon_eq_standard_chest_ironbrigandine.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Gold-Thread Trousers",
-					"level": 30,
-					"materials": {"copper-bar": 4000, "kingswood-oak": 4000, "milk-of-the-poppy": 4000},
-					"img": "item/30-45/icon_eq_standard_pants_gold-threadtrousers.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Steel Culet",
-					"level": 30,
-					"materials": {"black-iron": 4000, "kingswood-oak": 4000, "goldenheart-wood": 4000},
-					"img": "item/30-45/icon_eq_standard_pants_steelculet.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Iron Poleyns",
-					"level": 30,
-					"materials": {"black-iron": 4000, "ironwood": 4000, "hide": 4000},
-					"img": "item/30-45/icon_eq_standard_pants_ironpoleyns.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Pathfinder's Boots",
-					"level": 30,
-					"materials": {"ironwood": 4000, "kingswood-oak": 4000, "milk-of-the-poppy": 4000},
-					"img": "item/30-45/icon_eq_standard_boots_pathfindersboots.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Silver Sabatons",
-					"level": 30,
-					"materials": {"copper-bar": 4000, "leather-straps": 4000, "milk-of-the-poppy": 4000},
-					"img": "item/30-45/icon_eq_standard_boots_silversabatons.png",
-					"odds": "medium",
-				},
-								{
-					"name": "Spiked Boots",
-					"level": 30,
-					"materials": {"leather-straps": 3000, "copper-bar": 3000, "wildfire": 3000, "dragonglass": 3000},
-					"img": "item/30-45/icon_eq_standard_boots_spikedboots.png",
-					"odds": "normal",
-				},
-				{
-					"name": "Obsidian Ring",
-					"level": 30,
-					"materials": {"black-iron": 4000, "wildfire": 4000, "silk": 4000},
-					"img": "item/30-45/icon_eq_standard_ring_obsidianring.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Lead Band",
-					"level": 30,
-					"materials": {"black-iron": 4000, "milk-of-the-poppy": 4000, "silk": 4000},
-					"img": "item/30-45/icon_eq_standard_ring_leadband.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Electrum & Bronze Braid",
-					"level": 30,
-					"materials": {"copper-bar": 4000, "black-iron": 4000, "milk-of-the-poppy": 4000},
-					"img": "item/30-45/icon_eq_standard_ring_electrumbronzebraid.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Recurve Bow",
-					"level": 30,
-					"materials": {"goldenheart-wood": 4000, "hide": 4000, "black-iron": 4000},
-					"img": "item/30-45/icon_eq_standard_weapon_recurvebow.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Glaive",
-					"level": 30,
-					"materials": {"leather-straps": 4000, "copper-bar": 4000, "hide": 4000},
-					"img": "item/30-45/icon_eq_standard_weapon_glaive.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Bastard Sword",
-					"level": 30,
-					"materials": {"weirwood": 4000, "leather-straps": 4000, "hide": 4000},
-					"img": "item/30-45/icon_eq_standard_weapon_bastardsword.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Helm",
-					"level": 30,
-					"materials": {"kingswood-oak": 3000, "wildfire": 3000, "hide": 3000, "milk-of-the-poppy": 3000},
-					"img": "item/ctw-head.png",
-					"odds": "normal",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Chestplate",
-					"level": 30,
-					"materials": {"silk": 3000, "black-iron": 3000, "copper-bar": 3000, "dragonglass": 3000},
-					"img": "item/ctw-chest.png",
-					"odds": "normal",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Pants",
-					"level": 30,
-					"materials": {"weirwood": 3000, "leather-straps": 3000, "black-iron": 3000, "silk": 3000},
-					"img": "item/ctw-pants.png",
-					"odds": "normal",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Sword",
-					"level": 30,
-					"materials": {"copper-bar": 3000, "dragonglass": 3000, "leather-straps": 3000, "weirwood": 3000},
-					"img": "item/ctw-weapon.png",
-					"odds": "normal",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Ring",
-					"level": 30,
-					"materials": {"ironwood": 3000, "goldenheart-wood": 3000, "wildfire": 3000, "kingswood-oak": 3000},
-					"img": "item/ctw-ring.png",
-					"odds": "normal",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Boots",
-					"level": 30,
-					"materials": {"milk-of-the-poppy": 3000, "hide": 3000, "ironwood": 3000, "goldenheart-wood": 3000},
-					"img": "item/ctw-boots.png",
-					"odds": "normal",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Emerald Forehead Pendant",
-					"level": 35,
-					"materials": {"dragonglass": 16000, "hide": 16000, "silk": 16000},
-					"img": "item/30-45/icon_eq_standard_helmet_emeraldforeheadpendant.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Casque",
-					"level": 35,
-					"materials": {"copper-bar": 16000, "kingswood-oak": 16000, "hide": 16000},
-					"img": "item/30-45/icon_eq_standard_helmet_casque.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Silk Chapeau",
-					"level": 35,
-					"materials": {"silk": 16000, "leather-straps": 16000, "milk-of-the-poppy": 16000},
-					"img": "item/30-45/icon_eq_standard_helmet_silkchapeau.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Satin Dress",
-					"level": 35,
-					"materials": {"silk": 24000, "milk-of-the-poppy": 24000},
-					"img": "item/30-45/icon_eq_standard_chest_satindress.png",
-					"odds": "low",
-				},
-				{
-					"name": "Steel Chainmail",
-					"level": 35,
-					"materials": {"leather-straps": 16000, "copper-bar": 16000, "black-iron": 16000},
-					"img": "item/30-45/icon_eq_standard_chest_steelchainmail.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Silvered Brigandine",
-					"level": 35,
-					"materials": {"ironwood": 24000, "dragonglass": 24000},
-					"img": "item/30-45/icon_eq_standard_chest_silveredbrigandine.png",
-					"odds": "low",
-				},
-				{
-					"name": "Electrum Tasset",
-					"level": 35,
-					"materials": {"copper-bar": 16000, "hide": 16000, "weirwood": 16000},
-					"img": "item/30-45/icon_eq_standard_pants_electrumtasset.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Fur-Lined Britches",
-					"level": 35,
-					"materials": {"hide": 16000, "ironwood": 16000, "kingswood-oak": 16000},
-					"img": "item/30-45/icon_eq_standard_pants_fur-linedbritches.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Balzarine Skirt",
-					"level": 35,
-					"materials": {"silk": 16000, "milk-of-the-poppy": 16000, "wildfire": 16000},
-					"img": "item/30-45/icon_eq_standard_pants_balzarineskirt.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Earthshakers",
-					"level": 35,
-					"materials": {"black-iron": 16000, "weirwood": 16000, "ironwood": 16000},
-					"img": "item/30-45/icon_eq_standard_boots_earthshakers.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Gold Sabatons",
-					"level": 35,
-					"materials": {"silk": 16000, "copper-bar": 16000, "milk-of-the-poppy": 16000},
-					"img": "item/30-45/icon_eq_standard_boots_goldsabatons.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Winged Boots",
-					"level": 35,
-					"materials": {"leather-straps": 16000, "wildfire": 16000, "dragonglass": 16000},
-					"img": "item/30-45/icon_eq_standard_boots_wingedboots.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Ecclesiastical Ring",
-					"level": 35,
-					"materials": {"dragonglass": 16000, "ironwood": 16000, "weirwood": 16000},
-					"img": "item/30-45/icon_eq_standard_ring_ecclesiasticalring.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Pale Steel Band",
-					"level": 35,
-					"materials": {"dragonglass": 16000, "weirwood": 16000, "goldenheart-wood": 16000},
-					"img": "item/30-45/icon_eq_standard_ring_palesteelband.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Poison Ring",
-					"level": 35,
-					"materials": {"dragonglass": 16000, "leather-straps": 16000, "black-iron": 16000},
-					"img": "item/30-45/icon_eq_standard_ring_poisonring.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Long Bow",
-					"level": 35,
-					"materials": {"goldenheart-wood": 12000, "silk": 12000, "hide": 12000, "dragonglass": 12000},
-					"img": "item/30-45/icon_eq_standard_weapon_longbow.png",
-					"odds": "normal",
-				},
-				{
-					"name": "Lance",
-					"level": 35,
-					"materials": {"leather-straps": 16000, "copper-bar": 16000, "black-iron": 16000},
-					"img": "item/30-45/icon_eq_standard_weapon_lance.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Falchion",
-					"level": 35,
-					"materials": {"ironwood": 16000, "black-iron": 16000, "copper-bar": 16000},
-					"img": "item/30-45/icon_eq_standard_weapon_falchion.png",
-					"odds": "medium",
-				},
-				{
-					"name": "Helm",
-					"level": 35,
-					"materials": {"kingswood-oak": 12000, "wildfire": 12000, "hide": 12000, "milk-of-the-poppy": 12000},
-					"img": "item/ctw-head.png",
-					"odds": "normal",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Chestplate",
-					"level": 35,
-					"materials": {"silk": 12000, "black-iron": 12000, "copper-bar": 12000, "dragonglass": 12000},
-					"img": "item/ctw-chest.png",
-					"odds": "normal",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Pants",
-					"level": 35,
-					"materials": {"weirwood": 12000, "leather-straps": 12000, "black-iron": 12000, "silk": 12000},
-					"img": "item/ctw-pants.png",
-					"odds": "normal",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Sword",
-					"level": 35,
-					"materials": {"copper-bar": 12000, "dragonglass": 12000, "leather-straps": 12000, "weirwood": 12000},
-					"img": "item/ctw-weapon.png",
-					"odds": "normal",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Ring",
-					"level": 35,
-					"materials": {"ironwood": 12000, "goldenheart-wood": 12000, "wildfire": 12000, "kingswood-oak": 12000},
-					"img": "item/ctw-ring.png",
-					"odds": "normal",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Boots",
-					"level": 35,
-					"materials": {"milk-of-the-poppy": 12000, "hide": 12000, "ironwood": 12000, "goldenheart-wood": 12000},
-					"img": "item/ctw-boots.png",
-					"odds": "normal",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Golden Crown",
-					"level": 40,
-					"materials": {"copper-bar": 45000, "leather-straps": 45000, "hide": 45000, "kingswood-oak": 45000},
-					"img": "item/30-45/icon_eq_standard_helmet_goldencrown.png",
-					"odds": "normal"
-				},
-				{
-					"name": "Mark Of The Seven",
-					"level": 40,
-					"materials": {"wildfire": 45000, "kingswood-oak": 45000, "weirwood": 45000, "goldenheart-wood": 45000},
-					"img": "item/30-45/icon_eq_standard_helmet_markoftheseven.png",
-					"odds": "normal"
-				},
-				{
-					"name": "Copper Circlet",
-					"level": 40,
-					"materials": {"copper-bar": 60000, "goldenheart-wood": 60000, "weirwood": 60000},
-					"img": "item/30-45/icon_eq_standard_helmet_coppercirclet.png",
-					"odds": "medium"
-				},
-				{
-					"name": "Courtesan's Outfit",
-					"level": 40,
-					"materials": {"silk": 60000, "leather-straps": 60000, "milk-of-the-poppy": 60000},
-					"img": "item/30-45/icon_eq_standard_chest_courtesansoutfit.png",
-					"odds": "medium"
-				},
-				{
-					"name": "Electrum Scalemail",
-					"level": 40,
-					"materials": {"weirwood": 45000, "kingswood-oak": 45000, "copper-bar": 45000, "black-iron": 45000},
-					"img": "item/30-45/icon_eq_standard_chest_electrumscalemail.png",
-					"odds": "normal"
-				},
-				{
-					"name": "Iron Scalemail",
-					"level": 40,
-					"materials": {"goldenheart-wood": 45000, "kingswood-oak": 45000, "black-iron": 45000, "leather-straps": 45000},
-					"img": "item/30-45/icon_eq_standard_chest_ironscalemail.png",
-					"odds": "normal"
-				},
-				{
-					"name": "Bronze Cuisse",
-					"level": 40,
-					"materials": {"copper-bar": 45000, "weirwood": 45000, "goldenheart-wood": 45000, "hide": 45000},
-					"img": "item/30-45/icon_eq_standard_pants_bronzecuisse.png",
-					"odds": "normal"
-				},
-				{
-					"name": "Velour Pants",
-					"level": 40,
-					"materials": {"hide": 45000, "wildfire": 45000, "milk-of-the-poppy": 45000, "kingswood-oak": 45000},
-					"img": "item/30-45/icon_eq_standard_pants_velourpants.png",
-					"odds": "normal"
-				},
-				{
-					"name": "Iron Greaves",
-					"level": 40,
-					"materials": {"black-iron": 45000, "ironwood": 45000, "wildfire": 45000, "copper-bar": 45000},
-					"img": "item/30-45/icon_eq_standard_pants_irongreaves.png",
-					"odds": "normal"
-				},
-				{
-					"name": "Copper Spiked Kickers",
-					"level": 40,
-					"materials": {"copper-bar": 45000, "leather-straps": 45000, "wildfire": 45000, "milk-of-the-poppy": 45000},
-					"img": "item/30-45/icon_eq_standard_boots_copperspikedkickers.png",
-					"odds": "normal"
-				},
-				{
-					"name": "Black Iron Sabatons",
-					"level": 40,
-					"materials": {"silk": 45000, "black-iron": 45000, "wildfire": 45000, "hide": 45000},
-					"img": "item/30-45/icon_eq_standard_boots_blackironsabatons.png",
-					"odds": "normal"
-				},
-				{
-					"name": "Blackwater Treads",
-					"level": 40,
-					"materials": {"weirwood": 45000, "black-iron": 45000, "hide": 45000, "kingswood-oak": 45000},
-					"img": "item/30-45/icon_eq_standard_boots_blackwatertreads.png",
-					"odds": "normal"
-				},
-				{
-					"name": "Sapphire Ring",
-					"level": 40,
-					"materials": {"dragonglass": 45000, "weirwood": 45000, "hide": 45000, "milk-of-the-poppy": 45000},
-					"img": "item/30-45/icon_eq_standard_ring_sapphire.png",
-					"odds": "normal"
-				},
-				{
-					"name": "Ruby Ring",
-					"level": 40,
-					"materials": {"dragonglass": 45000, "kingswood-oak": 45000, "silk": 45000, "milk-of-the-poppy": 45000},
-					"img": "item/30-45/icon_eq_standard_ring_ruby.png",
-					"odds": "normal"
-				},
-				{
-					"name": "Iron Ring",
-					"level": 40,
-					"materials": {"black-iron": 45000, "leather-straps": 45000, "ironwood": 45000, "goldenheart-wood": 45000},
-					"img": "item/30-45/icon_eq_standard_ring_ironring.png",
-					"odds": "normal"
-				},
-				{
-					"name": "heavy Crossbow",
-					"level": 40,
-					"materials": {"weirwood": 45000, "leather-straps": 45000, "hide": 45000, "dragonglass": 45000},
-					"img": "item/30-45/icon_eq_standard_weapon_heavycrossbow.png",
-					"odds": "normal"
-				},
-				{
-					"name": "Long Sword",
-					"level": 40,
-					"materials": {"weirwood": 45000, "kingswood-oak": 45000, "copper-bar": 45000, "black-iron": 45000},
-					"img": "item/30-45/icon_eq_standard_weapon_longsword.png",
-					"odds": "normal"
-				},
-				{
-					"name": "Poleaxe",
-					"level": 40,
-					"materials": {"goldenheart-wood": 45000, "kingswood-oak": 45000, "black-iron": 45000, "leather-straps": 45000},
-					"img": "item/30-45/icon_eq_standard_weapon_poleaxe.png",
-					"odds": "normal"
-				},
-				{
-					"name": "Helm",
-					"level": 40,
-					"materials": {"kingswood-oak": 45000, "wildfire": 45000, "hide": 45000, "milk-of-the-poppy": 45000},
-					"img": "item/ctw-head.png",
-					"odds": "normal",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Chestplate",
-					"level": 40,
-					"materials": {"silk": 45000, "black-iron": 45000, "copper-bar": 45000, "dragonglass": 45000},
-					"img": "item/ctw-chest.png",
-					"odds": "normal",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Pants",
-					"level": 40,
-					"materials": {"weirwood": 45000, "leather-straps": 45000, "black-iron": 45000, "silk": 45000},
-					"img": "item/ctw-pants.png",
-					"odds": "normal",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Sword",
-					"level": 40,
-					"materials": {"copper-bar": 45000, "dragonglass": 45000, "leather-straps": 45000, "weirwood": 45000},
-					"img": "item/ctw-weapon.png",
-					"odds": "normal",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Ring",
-					"level": 40,
-					"materials": {"ironwood": 45000, "goldenheart-wood": 45000, "wildfire": 45000, "kingswood-oak": 45000},
-					"img": "item/ctw-ring.png",
-					"odds": "normal",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Boots",
-					"level": 40,
-					"materials": {"milk-of-the-poppy": 45000, "hide": 45000, "ironwood": 45000, "goldenheart-wood": 45000},
-					"img": "item/ctw-boots.png",
-					"odds": "normal",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Jewl Encrusted Tiara",
-					"level": 45,
-					"materials": {"dragonglass": 120000, "wildfire": 120000, "kingswood-oak": 120000, "silk": 120000},
-					"img": "item/30-45/icon_eq_standard_helmet_jewelencrustedtiara.png",
-					"odds": "normal"
-				},
-				{
-					"name": "Assassin's Cowl",
-					"level": 45,
-					"materials": {"silk": 120000, "leather-straps": 120000, "hide": 120000, "kingswood-oak": 120000},
-					"img": "item/30-45/icon_eq_standard_helmet_assassinscowl.png",
-					"odds": "normal"
-				},
-				{
-					"name": "Sapphire Forehead Pendant",
-					"level": 45,
-					"materials": {"dragonglass": 120000, "ironwood": 120000, "kingswood-oak": 120000, "hide": 120000},
-					"img": "item/30-45/icon_eq_standard_helmet_sapphireforeheadpendant.png",
-					"odds": "normal"
-				},
-				{
-					"name": "Golden Raiment",
-					"level": 45,
-					"materials": {"goldenheart-wood": 120000, "copper-bar": 120000, "weirwood": 120000, "ironwood": 120000},
-					"img": "item/30-45/icon_eq_standard_chest_goldenraiment.png",
-					"odds": "normal"
-				},
-				{
-					"name": "Bronze Cuirass",
-					"level": 45,
-					"materials": {"ironwood": 120000, "kingswood-oak": 120000, "hide": 120000, "dragonglass": 120000},
-					"img": "item/30-45/icon_eq_standard_chest_bronzecuirass.png",
-					"odds": "normal"
-				},
-				{
-					"name": "Lead Cuirass",
-					"level": 45,
-					"materials": {"black-iron": 120000, "weirwood": 120000, "silk": 120000, "goldenheart-wood": 120000},
-					"img": "item/30-45/icon_eq_standard_chest_leadcuirass.png",
-					"odds": "normal"
-				},
-				{
-					"name": "Steel Greaves",
-					"level": 45,
-					"materials": {"black-iron": 120000, "ironwood": 120000, "weirwood": 120000, "goldenheart-wood": 120000},
-					"img": "item/30-45/icon_eq_standard_pants_steelgreaves.png",
-					"odds": "normal"
-				},
-				{
-					"name": "Wolf Pelt Trousers",
-					"level": 45,
-					"materials": {"hide": 120000, "kingswood-oak": 120000, "silk": 120000, "milk-of-the-poppy": 120000},
-					"img": "item/30-45/icon_eq_standard_pants_wolfpelttrousers.png",
-					"odds": "normal"
-				},
-				{
-					"name": "Satin Skirt",
-					"level": 45,
-					"materials": {"silk": 120000, "milk-of-the-poppy": 120000, "kingswood-oak": 120000, "copper-bar": 120000},
-					"img": "item/30-45/icon_eq_standard_pants_satinskirt.png",
-					"odds": "normal"
-				},
-				{
-					"name": "Lead Soled Shoes",
-					"level": 45,
-					"materials": {"kingswood-oak": 120000, "black-iron": 120000, "weirwood": 120000, "copper-bar": 120000},
-					"img": "item/30-45/icon_eq_standard_boots_leadsoledshoes.png",
-					"odds": "normal"
-				},
-				{
-					"name": "Copper Sabatons",
-					"level": 45,
-					"materials": {"copper-bar": 120000, "ironwood": 120000, "kingswood-oak": 120000, "milk-of-the-poppy": 120000},
-					"img": "item/30-45/icon_eq_standard_boots_coppersabatons.png",
-					"odds": "normal"
-				},
-				{
-					"name": "Spurred Treads",
-					"level": 45,
-					"materials": {"ironwood": 120000, "dragonglass": 120000, "goldenheart-wood": 120000, "hide": 120000},
-					"img": "item/30-45/icon_eq_standard_boots_spurredtreads.png",
-					"odds": "normal"
-				},
-				{
-					"name": "Pearl Ring",
-					"level": 45,
-					"materials": {"dragonglass": 120000, "hide": 120000, "ironwood": 120000, "goldenheart-wood": 120000},
-					"img": "item/30-45/icon_eq_standard_ring_pearl.png",
-					"odds": "normal"
-				},
-				{
-					"name": "Emerald Ring",
-					"level": 45,
-					"materials": {"dragonglass": 120000, "weirwood": 120000, "milk-of-the-poppy": 120000, "goldenheart-wood": 120000},
-					"img": "item/30-45/icon_eq_standard_ring_emerald.png",
-					"odds": "normal"
-				},
-				{
-					"name": "Gold Loop",
-					"level": 45,
-					"materials": {"copper-bar": 120000, "weirwood": 120000, "silk": 120000, "milk-of-the-poppy": 120000},
-					"img": "item/30-45/icon_eq_standard_ring_goldloop.png",
-					"odds": "normal"
-				},
-				{
-					"name": "Triple Crossbow",
-					"level": 45,
-					"materials": {"goldenheart-wood": 120000, "kingswood-oak": 120000, "weirwood": 120000, "ironwood": 120000},
-					"img": "item/30-45/icon_eq_standard_weapon_triplecrossbow.png",
-					"odds": "normal"
-				},
-				{
-					"name": "Morningstar",
-					"level": 45,
-					"materials": {"ironwood": 120000, "kingswood-oak": 120000, "hide": 120000, "wildfire": 120000},
-					"img": "item/30-45/icon_eq_standard_weapon_morningstar.png",
-					"odds": "normal"
-				},
-				{
-					"name": "Battle Axe",
-					"level": 45,
-					"materials": {"weirwood": 120000, "copper-bar": 120000, "silk": 120000, "goldenheart-wood": 120000},
-					"img": "item/30-45/icon_eq_standard_weapon_battleaxe.png",
-					"odds": "normal"
-				},
-				{
-					"name": "Helm",
-					"level": 45,
-					"materials": {"kingswood-oak": 120000, "wildfire": 120000, "hide": 120000, "milk-of-the-poppy": 120000},
-					"img": "item/ctw-head.png",
-					"odds": "normal",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Chestplate",
-					"level": 45,
-					"materials": {"silk": 120000, "black-iron": 120000, "copper-bar": 120000, "dragonglass": 120000},
-					"img": "item/ctw-chest.png",
-					"odds": "normal",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Pants",
-					"level": 45,
-					"materials": {"weirwood": 120000, "leather-straps": 120000, "black-iron": 120000, "silk": 120000},
-					"img": "item/ctw-pants.png",
-					"odds": "normal",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Sword",
-					"level": 45,
-					"materials": {"copper-bar": 120000, "dragonglass": 120000, "leather-straps": 120000, "weirwood": 120000},
-					"img": "item/ctw-weapon.png",
-					"odds": "normal",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Ring",
-					"level": 45,
-					"materials": {"ironwood": 120000, "goldenheart-wood": 120000, "wildfire": 120000, "kingswood-oak": 120000},
-					"img": "item/ctw-ring.png",
-					"odds": "normal",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-				{
-					"name": "Boots",
-					"level": 45,
-					"materials": {"milk-of-the-poppy": 120000, "hide": 120000, "ironwood": 120000, "goldenheart-wood": 120000},
-					"img": "item/ctw-boots.png",
-					"odds": "normal",
-					"warlord": true,
-					"setName": "Ceremonial Targaryen Warlord"
-				},
-			]
-		}
-	]
-}
+  "season": 0,
+  "sets": [
+    {
+      "products": [
+        {
+          "name": "Wooden Bucket",
+          "level": 1,
+          "materials": {
+            "weirwood": 10,
+            "kingswood-oak": 10
+          },
+          "img": "item/icon_eq_standard_helmet_woodenbucket.webp"
+        },
+        {
+          "name": "Leather Vest",
+          "level": 1,
+          "materials": {
+            "hide": 10,
+            "leather-straps": 10
+          },
+          "img": "item/icon_eq_standard_chest_leathervest.webp"
+        },
+        {
+          "name": "Flax Legwraps",
+          "level": 1,
+          "materials": {
+            "milk-of-the-poppy": 10,
+            "goldenheart-wood": 10
+          },
+          "img": "item/icon_eq_standard_pants_flaxlegwraps.webp"
+        },
+        {
+          "name": "Straw Sandals",
+          "level": 1,
+          "materials": {
+            "hide": 10,
+            "leather-straps": 10
+          },
+          "img": "item/icon_eq_standard_boots_strawsandals.webp"
+        },
+        {
+          "name": "Copper Band",
+          "level": 1,
+          "materials": {
+            "black-iron": 10,
+            "copper-bar": 10
+          },
+          "img": "item/icon_eq_standard_ring_copperband.webp"
+        },
+        {
+          "name": "Dagger",
+          "level": 1,
+          "materials": {
+            "ironwood": 10,
+            "kingswood-oak": 10
+          },
+          "img": "item/icon_eq_standard_weapon_dagger.png"
+        },
+        {
+          "name": "Wool Bandana",
+          "level": 5,
+          "materials": {
+            "kingswood-oak": 15,
+            "milk-of-the-poppy": 15
+          },
+          "img": "item/icon_eq_standard_helmet_woolbandana.webp"
+        },
+        {
+          "name": "Boiled Leather Shirt",
+          "level": 5,
+          "materials": {
+            "hide": 15,
+            "dragonglass": 15
+          },
+          "img": "item/icon_eq_standard_chest_boiledleathershirt.webp"
+        },
+        {
+          "name": "Leather Poleyns",
+          "level": 5,
+          "materials": {
+            "hide": 15,
+            "leather-straps": 15
+          },
+          "img": "item/icon_eq_standard_pants_leatherpoleyns.webp"
+        },
+        {
+          "name": "Leather Booties",
+          "level": 5,
+          "materials": {
+            "hide": 10,
+            "silk": 10,
+            "weirwood": 10
+          },
+          "img": "item/icon_eq_standard_boots_leatherbooties.webp"
+        },
+        {
+          "name": "Bronze Band",
+          "level": 5,
+          "materials": {
+            "copper-bar": 15,
+            "milk-of-the-poppy": 15
+          },
+          "img": "item/icon_eq_standard_ring_bronzeband.webp"
+        },
+        {
+          "name": "Spear",
+          "level": 5,
+          "materials": {
+            "leather-straps": 15,
+            "wildfire": 15
+          },
+          "img": "item/icon_eq_standard_weapon_spear.webp"
+        },
+        {
+          "name": "Copper Pot",
+          "level": 10,
+          "materials": {
+            "copper-bar": 30,
+            "leather-straps": 30
+          },
+          "img": "item/icon_eq_standard_helmet_copperpot.webp"
+        },
+        {
+          "name": "Straw hat",
+          "level": 10,
+          "materials": {
+            "dragonglass": 20,
+            "silk": 20,
+            "leather-straps": 20
+          },
+          "img": "item/icon_eq_standard_helmet_strawhat.webp"
+        },
+        {
+          "name": "Wool Robe",
+          "level": 10,
+          "materials": {
+            "milk-of-the-poppy": 30,
+            "hide": 30
+          },
+          "img": "item/icon_eq_standard_chest_woolrobe.webp"
+        },
+        {
+          "name": "Padded Armor",
+          "level": 10,
+          "materials": {
+            "silk": 30,
+            "ironwood": 30
+          },
+          "img": "item/icon_eq_standard_chest_paddedarmor.webp"
+        },
+        {
+          "name": "Wool Leggings",
+          "level": 10,
+          "materials": {
+            "hide": 30,
+            "wildfire": 30
+          },
+          "img": "item/icon_eq_standard_pants_woolleggings.webp"
+        },
+        {
+          "name": "Ragged Shorts",
+          "level": 10,
+          "materials": {
+            "leather-straps": 30,
+            "milk-of-the-poppy": 30
+          },
+          "img": "item/icon_eq_standard_pants_raggedshorts.webp"
+        },
+        {
+          "name": "Velvet Boots",
+          "level": 10,
+          "materials": {
+            "silk": 30,
+            "wildfire": 30
+          },
+          "img": "item/icon_eq_standard_boots_velvetboots.webp"
+        },
+        {
+          "name": "Galoshes",
+          "level": 10,
+          "materials": {
+            "weirwood": 30,
+            "ironwood": 30
+          },
+          "img": "item/icon_eq_standard_boots_galoshes.webp"
+        },
+        {
+          "name": "Pyrite Lament",
+          "level": 10,
+          "materials": {
+            "dragonglass": 30,
+            "kingswood-oak": 30
+          },
+          "img": "item/icon_eq_standard_ring_pyritelament.webp"
+        },
+        {
+          "name": "Quartz Ring",
+          "level": 10,
+          "materials": {
+            "dragonglass": 30,
+            "weirwood": 30
+          },
+          "img": "item/icon_eq_standard_ring_quartzring.webp"
+        },
+        {
+          "name": "Mace",
+          "level": 10,
+          "materials": {
+            "weirwood": 30,
+            "black-iron": 30
+          },
+          "img": "item/icon_eq_standard_weapon_mace.webp"
+        },
+        {
+          "name": "Short Bow",
+          "level": 10,
+          "materials": {
+            "silk": 30,
+            "goldenheart-wood": 30
+          },
+          "img": "item/icon_eq_standard_weapon_shortbow.webp"
+        },
+        {
+          "name": "Iron Skullcap",
+          "level": 15,
+          "materials": {
+            "black-iron": 180,
+            "leather-straps": 180
+          },
+          "odds": "medium",
+          "img": "item/15-25/icon_eq_standard_helmet_ironskullcap.png"
+        },
+        {
+          "name": "Steel Gorget",
+          "level": 15,
+          "materials": {
+            "black-iron": 180,
+            "milk-of-the-poppy": 180
+          },
+          "odds": "medium",
+          "img": "item/15-25/icon_eq_standard_helmet_steelgorget.png"
+        },
+        {
+          "name": "Mushroom Cap",
+          "level": 15,
+          "materials": {
+            "wildfire": 180,
+            "weirwood": 180
+          },
+          "odds": "medium",
+          "img": "item/15-25/icon_eq_standard_helmet_mushroomcap.png"
+        },
+        {
+          "name": "Lab Smock",
+          "level": 15,
+          "materials": {
+            "wildfire": 180,
+            "silk": 180
+          },
+          "odds": "medium",
+          "img": "item/15-25/icon_eq_standard_chest_labsmock.png"
+        },
+        {
+          "name": "Bronze Chain Shirt",
+          "level": 15,
+          "materials": {
+            "copper-bar": 180,
+            "hide": 180
+          },
+          "odds": "medium",
+          "img": "item/15-25/icon_eq_standard_chest_bronzechainshirt.png"
+        },
+        {
+          "name": "Charred Leathers",
+          "level": 15,
+          "materials": {
+            "leather-straps": 180,
+            "wildfire": 180
+          },
+          "odds": "medium",
+          "img": "item/15-25/icon_eq_standard_chest_charredleathers.png"
+        },
+        {
+          "name": "Leather Schynbalds",
+          "level": 15,
+          "materials": {
+            "leather-straps": 180,
+            "ironwood": 180
+          },
+          "odds": "medium",
+          "img": "item/15-25/icon_eq_standard_pants_leatherschynbalds.png"
+        },
+        {
+          "name": "Leather Kilt",
+          "level": 15,
+          "materials": {
+            "hide": 180,
+            "kingswood-oak": 180
+          },
+          "odds": "medium",
+          "img": "item/15-25/icon_eq_standard_pants_leatherkilt.png"
+        },
+        {
+          "name": "Copper Culet",
+          "level": 15,
+          "materials": {
+            "copper-bar": 180,
+            "wildfire": 180
+          },
+          "odds": "medium",
+          "img": "item/15-25/icon_eq_standard_pants_copperculet.png"
+        },
+        {
+          "name": "Well-Heeled Shoes",
+          "level": 15,
+          "materials": {
+            "weirwood": 120,
+            "silk": 120,
+            "dragonglass": 120
+          },
+          "odds": "normal",
+          "img": "item/15-25/icon_eq_standard_boots_well-heeledshoes.png"
+        },
+        {
+          "name": "Steel-Toed Stompers",
+          "level": 15,
+          "materials": {
+            "black-iron": 120,
+            "goldenheart-wood": 120,
+            "weirwood": 120
+          },
+          "odds": "normal",
+          "img": "item/15-25/icon_eq_standard_boots_steel-toedstompers.png"
+        },
+        {
+          "name": "Riding Boots",
+          "level": 15,
+          "materials": {
+            "leather-straps": 180,
+            "kingswood-oak": 180
+          },
+          "odds": "medium",
+          "img": "item/15-25/icon_eq_standard_boots_ridingboots.png"
+        },
+        {
+          "name": "Amethyst Embrace",
+          "level": 15,
+          "materials": {
+            "dragonglass": 180,
+            "silk": 180
+          },
+          "odds": "medium",
+          "img": "item/15-25/icon_eq_standard_ring_amethystembrace.png"
+        },
+        {
+          "name": "Tiger's Eye Ring",
+          "level": 15,
+          "materials": {
+            "dragonglass": 180,
+            "kingswood-oak": 180
+          },
+          "odds": "medium",
+          "img": "item/15-25/icon_eq_standard_ring_tigerseye.png"
+        },
+        {
+          "name": "Silver Band",
+          "level": 15,
+          "materials": {
+            "ironwood": 180,
+            "milk-of-the-poppy": 180
+          },
+          "odds": "medium",
+          "img": "item/15-25/icon_eq_standard_ring_silverband.png"
+        },
+        {
+          "name": "Flatbow",
+          "level": 15,
+          "materials": {
+            "goldenheart-wood": 180,
+            "milk-of-the-poppy": 180
+          },
+          "odds": "medium",
+          "img": "item/15-25/icon_eq_standard_weapon_flatbow.png"
+        },
+        {
+          "name": "Pike",
+          "level": 15,
+          "materials": {
+            "goldenheart-wood": 180,
+            "hide": 180
+          },
+          "odds": "medium",
+          "img": "item/15-25/icon_eq_standard_weapon_pike.png"
+        },
+        {
+          "name": "Short Sword",
+          "level": 15,
+          "materials": {
+            "ironwood": 180,
+            "copper-bar": 180
+          },
+          "odds": "medium",
+          "img": "item/15-25/icon_eq_standard_weapon_shortsword.png"
+        },
+        {
+          "name": "Halfhelm",
+          "level": 20,
+          "materials": {
+            "copper-bar": 600,
+            "ironwood": 600
+          },
+          "img": "item/15-25/icon_eq_standard_helmet_halfhelm.png",
+          "odds": "low"
+        },
+        {
+          "name": "Turban",
+          "level": 20,
+          "materials": {
+            "silk": 600,
+            "leather-straps": 600
+          },
+          "img": "item/15-25/icon_eq_standard_helmet_turban.png",
+          "odds": "low"
+        },
+        {
+          "name": "Wool Coif",
+          "level": 20,
+          "materials": {
+            "hide": 600,
+            "wildfire": 600
+          },
+          "img": "item/15-25/icon_eq_standard_helmet_woolcoif.png",
+          "odds": "low"
+        },
+        {
+          "name": "Merchant's Doublet",
+          "level": 20,
+          "materials": {
+            "silk": 600,
+            "dragonglass": 600
+          },
+          "img": "item/15-25/icon_eq_standard_chest_merchantsdoublet.png",
+          "odds": "low"
+        },
+        {
+          "name": "Copper Chain Shirt",
+          "level": 20,
+          "materials": {
+            "copper-bar": 600,
+            "leather-straps": 600
+          },
+          "img": "item/15-25/icon_eq_standard_chest_copperchainshirt.png",
+          "odds": "low"
+        },
+        {
+          "name": "Iron Chain Shirt",
+          "level": 20,
+          "materials": {
+            "black-iron": 600,
+            "leather-straps": 600
+          },
+          "img": "item/15-25/icon_eq_standard_chest_ironchainshirt.png",
+          "odds": "low"
+        },
+        {
+          "name": "Wool Skirt",
+          "level": 20,
+          "materials": {
+            "hide": 600,
+            "leather-straps": 600
+          },
+          "img": "item/15-25/icon_eq_standard_pants_woolskirt.png",
+          "odds": "low"
+        },
+        {
+          "name": "Leather Chaps",
+          "level": 20,
+          "materials": {
+            "leather-straps": 600,
+            "goldenheart-wood": 600
+          },
+          "img": "item/15-25/icon_eq_standard_pants_leatherchaps.png",
+          "odds": "low"
+        },
+        {
+          "name": "Wooden Poleyns",
+          "level": 20,
+          "materials": {
+            "goldenheart-wood": 600,
+            "kingswood-oak": 600
+          },
+          "img": "item/15-25/icon_eq_standard_pants_woodenpoleyns.png",
+          "odds": "low"
+        },
+        {
+          "name": "Boots of War",
+          "level": 20,
+          "materials": {
+            "weirwood": 600,
+            "ironwood": 600
+          },
+          "img": "item/15-25/icon_eq_standard_boots_bootsofwar.png",
+          "odds": "low"
+        },
+        {
+          "name": "Sandstompers",
+          "level": 20,
+          "materials": {
+            "leather-straps": 600,
+            "dragonglass": 600
+          },
+          "img": "item/15-25/icon_eq_standard_boots_sandstompers.png",
+          "odds": "low"
+        },
+        {
+          "name": "Trail Rider's Gaiters",
+          "level": 20,
+          "materials": {
+            "hide": 600,
+            "leather-straps": 600
+          },
+          "img": "item/15-25/icon_eq_standard_boots_trailridersgaiters.png",
+          "odds": "low"
+        },
+        {
+          "name": "Episcopal Ring",
+          "level": 20,
+          "materials": {
+            "milk-of-the-poppy": 600,
+            "silk": 600
+          },
+          "img": "item/15-25/icon_eq_standard_ring_episcopalring.png",
+          "odds": "low"
+        },
+        {
+          "name": "Mourning Ring",
+          "level": 20,
+          "materials": {
+            "dragonglass": 600,
+            "ironwood": 600
+          },
+          "img": "item/15-25/icon_eq_standard_ring_mourningring.png",
+          "odds": "low"
+        },
+        {
+          "name": "Steel Band",
+          "level": 20,
+          "materials": {
+            "black-iron": 600,
+            "leather-straps": 600
+          },
+          "img": "item/15-25/icon_eq_standard_ring_steelband.png",
+          "odds": "low"
+        },
+        {
+          "name": "Net",
+          "level": 20,
+          "materials": {
+            "leather-straps": 600,
+            "silk": 600
+          },
+          "img": "item/15-25/icon_eq_standard_weapon_net.png",
+          "odds": "low"
+        },
+        {
+          "name": "Flail",
+          "level": 20,
+          "materials": {
+            "hide": 600,
+            "kingswood-oak": 600
+          },
+          "img": "item/15-25/icon_eq_standard_weapon_flail.png",
+          "odds": "low"
+        },
+        {
+          "name": "Rapier",
+          "level": 20,
+          "materials": {
+            "black-iron": 600,
+            "wildfire": 600
+          },
+          "img": "item/15-25/icon_eq_standard_weapon_rapier.png",
+          "odds": "low"
+        },
+        {
+          "name": "Pirate Tricorne",
+          "level": 25,
+          "materials": {
+            "hide": 1600,
+            "leather-straps": 1600,
+            "silk": 1600
+          },
+          "img": "item/15-25/icon_eq_standard_helmet_piratetricorne.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Lead Circlet",
+          "level": 25,
+          "materials": {
+            "black-iron": 1600,
+            "ironwood": 1600,
+            "dragonglass": 1600
+          },
+          "img": "item/15-25/icon_eq_standard_helmet_leadcirclet.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Traveler's Hood",
+          "level": 25,
+          "materials": {
+            "hide": 1600,
+            "milk-of-the-poppy": 1600,
+            "goldenheart-wood": 1600
+          },
+          "img": "item/15-25/icon_eq_standard_helmet_travelershood.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Maester's Robes",
+          "level": 25,
+          "materials": {
+            "milk-of-the-poppy": 2400,
+            "silk": 2400
+          },
+          "img": "item/15-25/icon_eq_standard_chest_maestersrobes.png",
+          "odds": "low"
+        },
+        {
+          "name": "Iron Chainmail",
+          "level": 25,
+          "materials": {
+            "leather-straps": 1600,
+            "black-iron": 1600,
+            "hide": 1600
+          },
+          "img": "item/15-25/icon_eq_standard_chest_ironchainmail.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Riveted Brigandine",
+          "level": 25,
+          "materials": {
+            "weirwood": 1600,
+            "copper-bar": 1600,
+            "dragonglass": 1600
+          },
+          "img": "item/15-25/icon_eq_standard_chest_rivetedbrigandine.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Bronze Chausses",
+          "level": 25,
+          "materials": {
+            "copper-bar": 1600,
+            "weirwood": 1600,
+            "ironwood": 1600
+          },
+          "img": "item/15-25/icon_eq_standard_pants_bronzechausses.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Golden Fauld",
+          "level": 25,
+          "materials": {
+            "copper-bar": 1600,
+            "silk": 1600,
+            "kingswood-oak": 1600
+          },
+          "img": "item/15-25/icon_eq_standard_pants_goldenfauld.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Tyroshi Leggings",
+          "level": 25,
+          "materials": {
+            "milk-of-the-poppy": 1600,
+            "wildfire": 1600,
+            "dragonglass": 1600
+          },
+          "img": "item/15-25/icon_eq_standard_pants_tyroshileggings.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Dancing Shoes",
+          "level": 25,
+          "materials": {
+            "milk-of-the-poppy": 1600,
+            "kingswood-oak": 1600,
+            "goldenheart-wood": 1600
+          },
+          "img": "item/15-25/icon_eq_standard_boots_dancingshoes.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Electrum Sabatons",
+          "level": 25,
+          "materials": {
+            "black-iron": 1600,
+            "copper-bar": 1600,
+            "leather-straps": 1600
+          },
+          "img": "item/15-25/icon_eq_standard_boots_electrumsabatons.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Knife-Toed Boots",
+          "level": 25,
+          "materials": {
+            "leather-straps": 2400,
+            "copper-bar": 2400
+          },
+          "img": "item/15-25/icon_eq_standard_boots_knifetoedboots.png",
+          "odds": "low"
+        },
+        {
+          "name": "Painite Ring",
+          "level": 25,
+          "materials": {
+            "dragonglass": 1600,
+            "leather-straps": 1600,
+            "goldenheart-wood": 1600
+          },
+          "img": "item/15-25/icon_eq_standard_ring_painite.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Opal Ring",
+          "level": 25,
+          "materials": {
+            "dragonglass": 1600,
+            "kingswood-oak": 1600,
+            "silk": 1600
+          },
+          "img": "item/15-25/icon_eq_standard_ring_opal.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Electrum Band",
+          "level": 25,
+          "materials": {
+            "copper-bar": 1600,
+            "weirwood": 1600,
+            "ironwood": 1600
+          },
+          "img": "item/15-25/icon_eq_standard_ring_electrumband.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Light Crossbow",
+          "level": 25,
+          "materials": {
+            "weirwood": 1600,
+            "silk": 1600,
+            "ironwood": 1600
+          },
+          "img": "item/15-25/icon_eq_standard_weapon_lightcrossbow.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Hand Axe",
+          "level": 25,
+          "materials": {
+            "leather-straps": 1600,
+            "black-iron": 1600,
+            "hide": 1600
+          },
+          "img": "item/15-25/icon_eq_standard_weapon_handaxe.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Gladius",
+          "level": 25,
+          "materials": {
+            "weirwood": 1600,
+            "black-iron": 1600,
+            "dragonglass": 1600
+          },
+          "img": "item/15-25/icon_eq_standard_weapon_gladius.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Kettle Helm",
+          "level": 30,
+          "materials": {
+            "copper-bar": 6000,
+            "goldenheart-wood": 6000
+          },
+          "img": "item/30-45/icon_eq_standard_helmet_kettlehelm.png",
+          "odds": "low"
+        },
+        {
+          "name": "Garnet Forehead Pendant",
+          "level": 30,
+          "materials": {
+            "dragonglass": 4000,
+            "leather-straps": 4000,
+            "wildfire": 4000
+          },
+          "img": "item/30-45/icon_eq_standard_helmet_garnetforeheadpendant.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Officer's Plumed Helm",
+          "level": 30,
+          "materials": {
+            "silk": 4000,
+            "dragonglass": 4000,
+            "hide": 4000
+          },
+          "img": "item/30-45/icon_eq_standard_helmet_officersplumedhelm.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Silk Tunic",
+          "level": 30,
+          "materials": {
+            "silk": 6000,
+            "milk-of-the-poppy": 6000
+          },
+          "img": "item/30-45/icon_eq_standard_chest_silktunic.png",
+          "odds": "low"
+        },
+        {
+          "name": "Gold Chainmail",
+          "level": 30,
+          "materials": {
+            "leather-straps": 6000,
+            "copper-bar": 6000
+          },
+          "img": "item/30-45/icon_eq_standard_chest_goldchainmail.png",
+          "odds": "low"
+        },
+        {
+          "name": "Iron Brigandine",
+          "level": 30,
+          "materials": {
+            "weirwood": 4000,
+            "leather-straps": 4000,
+            "hide": 4000
+          },
+          "img": "item/30-45/icon_eq_standard_chest_ironbrigandine.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Gold-Thread Trousers",
+          "level": 30,
+          "materials": {
+            "copper-bar": 4000,
+            "kingswood-oak": 4000,
+            "milk-of-the-poppy": 4000
+          },
+          "img": "item/30-45/icon_eq_standard_pants_gold-threadtrousers.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Steel Culet",
+          "level": 30,
+          "materials": {
+            "black-iron": 4000,
+            "kingswood-oak": 4000,
+            "goldenheart-wood": 4000
+          },
+          "img": "item/30-45/icon_eq_standard_pants_steelculet.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Iron Poleyns",
+          "level": 30,
+          "materials": {
+            "black-iron": 4000,
+            "ironwood": 4000,
+            "hide": 4000
+          },
+          "img": "item/30-45/icon_eq_standard_pants_ironpoleyns.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Pathfinder's Boots",
+          "level": 30,
+          "materials": {
+            "ironwood": 4000,
+            "kingswood-oak": 4000,
+            "milk-of-the-poppy": 4000
+          },
+          "img": "item/30-45/icon_eq_standard_boots_pathfindersboots.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Silver Sabatons",
+          "level": 30,
+          "materials": {
+            "copper-bar": 4000,
+            "leather-straps": 4000,
+            "milk-of-the-poppy": 4000
+          },
+          "img": "item/30-45/icon_eq_standard_boots_silversabatons.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Spiked Boots",
+          "level": 30,
+          "materials": {
+            "leather-straps": 3000,
+            "copper-bar": 3000,
+            "wildfire": 3000,
+            "dragonglass": 3000
+          },
+          "img": "item/30-45/icon_eq_standard_boots_spikedboots.png",
+          "odds": "normal"
+        },
+        {
+          "name": "Obsidian Ring",
+          "level": 30,
+          "materials": {
+            "black-iron": 4000,
+            "wildfire": 4000,
+            "silk": 4000
+          },
+          "img": "item/30-45/icon_eq_standard_ring_obsidianring.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Lead Band",
+          "level": 30,
+          "materials": {
+            "black-iron": 4000,
+            "milk-of-the-poppy": 4000,
+            "silk": 4000
+          },
+          "img": "item/30-45/icon_eq_standard_ring_leadband.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Electrum & Bronze Braid",
+          "level": 30,
+          "materials": {
+            "copper-bar": 4000,
+            "black-iron": 4000,
+            "milk-of-the-poppy": 4000
+          },
+          "img": "item/30-45/icon_eq_standard_ring_electrumbronzebraid.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Recurve Bow",
+          "level": 30,
+          "materials": {
+            "goldenheart-wood": 4000,
+            "hide": 4000,
+            "black-iron": 4000
+          },
+          "img": "item/30-45/icon_eq_standard_weapon_recurvebow.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Glaive",
+          "level": 30,
+          "materials": {
+            "leather-straps": 4000,
+            "copper-bar": 4000,
+            "hide": 4000
+          },
+          "img": "item/30-45/icon_eq_standard_weapon_glaive.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Bastard Sword",
+          "level": 30,
+          "materials": {
+            "weirwood": 4000,
+            "leather-straps": 4000,
+            "hide": 4000
+          },
+          "img": "item/30-45/icon_eq_standard_weapon_bastardsword.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Emerald Forehead Pendant",
+          "level": 35,
+          "materials": {
+            "dragonglass": 16000,
+            "hide": 16000,
+            "silk": 16000
+          },
+          "img": "item/30-45/icon_eq_standard_helmet_emeraldforeheadpendant.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Casque",
+          "level": 35,
+          "materials": {
+            "copper-bar": 16000,
+            "kingswood-oak": 16000,
+            "hide": 16000
+          },
+          "img": "item/30-45/icon_eq_standard_helmet_casque.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Silk Chapeau",
+          "level": 35,
+          "materials": {
+            "silk": 16000,
+            "leather-straps": 16000,
+            "milk-of-the-poppy": 16000
+          },
+          "img": "item/30-45/icon_eq_standard_helmet_silkchapeau.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Satin Dress",
+          "level": 35,
+          "materials": {
+            "silk": 24000,
+            "milk-of-the-poppy": 24000
+          },
+          "img": "item/30-45/icon_eq_standard_chest_satindress.png",
+          "odds": "low"
+        },
+        {
+          "name": "Steel Chainmail",
+          "level": 35,
+          "materials": {
+            "leather-straps": 16000,
+            "copper-bar": 16000,
+            "black-iron": 16000
+          },
+          "img": "item/30-45/icon_eq_standard_chest_steelchainmail.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Silvered Brigandine",
+          "level": 35,
+          "materials": {
+            "ironwood": 24000,
+            "dragonglass": 24000
+          },
+          "img": "item/30-45/icon_eq_standard_chest_silveredbrigandine.png",
+          "odds": "low"
+        },
+        {
+          "name": "Electrum Tasset",
+          "level": 35,
+          "materials": {
+            "copper-bar": 16000,
+            "hide": 16000,
+            "weirwood": 16000
+          },
+          "img": "item/30-45/icon_eq_standard_pants_electrumtasset.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Fur-Lined Britches",
+          "level": 35,
+          "materials": {
+            "hide": 16000,
+            "ironwood": 16000,
+            "kingswood-oak": 16000
+          },
+          "img": "item/30-45/icon_eq_standard_pants_fur-linedbritches.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Balzarine Skirt",
+          "level": 35,
+          "materials": {
+            "silk": 16000,
+            "milk-of-the-poppy": 16000,
+            "wildfire": 16000
+          },
+          "img": "item/30-45/icon_eq_standard_pants_balzarineskirt.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Earthshakers",
+          "level": 35,
+          "materials": {
+            "black-iron": 16000,
+            "weirwood": 16000,
+            "ironwood": 16000
+          },
+          "img": "item/30-45/icon_eq_standard_boots_earthshakers.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Gold Sabatons",
+          "level": 35,
+          "materials": {
+            "silk": 16000,
+            "copper-bar": 16000,
+            "milk-of-the-poppy": 16000
+          },
+          "img": "item/30-45/icon_eq_standard_boots_goldsabatons.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Winged Boots",
+          "level": 35,
+          "materials": {
+            "leather-straps": 16000,
+            "wildfire": 16000,
+            "dragonglass": 16000
+          },
+          "img": "item/30-45/icon_eq_standard_boots_wingedboots.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Ecclesiastical Ring",
+          "level": 35,
+          "materials": {
+            "dragonglass": 16000,
+            "ironwood": 16000,
+            "weirwood": 16000
+          },
+          "img": "item/30-45/icon_eq_standard_ring_ecclesiasticalring.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Pale Steel Band",
+          "level": 35,
+          "materials": {
+            "dragonglass": 16000,
+            "weirwood": 16000,
+            "goldenheart-wood": 16000
+          },
+          "img": "item/30-45/icon_eq_standard_ring_palesteelband.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Poison Ring",
+          "level": 35,
+          "materials": {
+            "dragonglass": 16000,
+            "leather-straps": 16000,
+            "black-iron": 16000
+          },
+          "img": "item/30-45/icon_eq_standard_ring_poisonring.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Long Bow",
+          "level": 35,
+          "materials": {
+            "goldenheart-wood": 12000,
+            "silk": 12000,
+            "hide": 12000,
+            "dragonglass": 12000
+          },
+          "img": "item/30-45/icon_eq_standard_weapon_longbow.png",
+          "odds": "normal"
+        },
+        {
+          "name": "Lance",
+          "level": 35,
+          "materials": {
+            "leather-straps": 16000,
+            "copper-bar": 16000,
+            "black-iron": 16000
+          },
+          "img": "item/30-45/icon_eq_standard_weapon_lance.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Falchion",
+          "level": 35,
+          "materials": {
+            "ironwood": 16000,
+            "black-iron": 16000,
+            "copper-bar": 16000
+          },
+          "img": "item/30-45/icon_eq_standard_weapon_falchion.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Golden Crown",
+          "level": 40,
+          "materials": {
+            "copper-bar": 45000,
+            "leather-straps": 45000,
+            "hide": 45000,
+            "kingswood-oak": 45000
+          },
+          "img": "item/30-45/icon_eq_standard_helmet_goldencrown.png",
+          "odds": "normal"
+        },
+        {
+          "name": "Mark Of The Seven",
+          "level": 40,
+          "materials": {
+            "wildfire": 45000,
+            "kingswood-oak": 45000,
+            "weirwood": 45000,
+            "goldenheart-wood": 45000
+          },
+          "img": "item/30-45/icon_eq_standard_helmet_markoftheseven.png",
+          "odds": "normal"
+        },
+        {
+          "name": "Copper Circlet",
+          "level": 40,
+          "materials": {
+            "copper-bar": 60000,
+            "goldenheart-wood": 60000,
+            "weirwood": 60000
+          },
+          "img": "item/30-45/icon_eq_standard_helmet_coppercirclet.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Courtesan's Outfit",
+          "level": 40,
+          "materials": {
+            "silk": 60000,
+            "leather-straps": 60000,
+            "milk-of-the-poppy": 60000
+          },
+          "img": "item/30-45/icon_eq_standard_chest_courtesansoutfit.png",
+          "odds": "medium"
+        },
+        {
+          "name": "Electrum Scalemail",
+          "level": 40,
+          "materials": {
+            "weirwood": 45000,
+            "kingswood-oak": 45000,
+            "copper-bar": 45000,
+            "black-iron": 45000
+          },
+          "img": "item/30-45/icon_eq_standard_chest_electrumscalemail.png",
+          "odds": "normal"
+        },
+        {
+          "name": "Iron Scalemail",
+          "level": 40,
+          "materials": {
+            "goldenheart-wood": 45000,
+            "kingswood-oak": 45000,
+            "black-iron": 45000,
+            "leather-straps": 45000
+          },
+          "img": "item/30-45/icon_eq_standard_chest_ironscalemail.png",
+          "odds": "normal"
+        },
+        {
+          "name": "Bronze Cuisse",
+          "level": 40,
+          "materials": {
+            "copper-bar": 45000,
+            "weirwood": 45000,
+            "goldenheart-wood": 45000,
+            "hide": 45000
+          },
+          "img": "item/30-45/icon_eq_standard_pants_bronzecuisse.png",
+          "odds": "normal"
+        },
+        {
+          "name": "Velour Pants",
+          "level": 40,
+          "materials": {
+            "hide": 45000,
+            "wildfire": 45000,
+            "milk-of-the-poppy": 45000,
+            "kingswood-oak": 45000
+          },
+          "img": "item/30-45/icon_eq_standard_pants_velourpants.png",
+          "odds": "normal"
+        },
+        {
+          "name": "Iron Greaves",
+          "level": 40,
+          "materials": {
+            "black-iron": 45000,
+            "ironwood": 45000,
+            "wildfire": 45000,
+            "copper-bar": 45000
+          },
+          "img": "item/30-45/icon_eq_standard_pants_irongreaves.png",
+          "odds": "normal"
+        },
+        {
+          "name": "Copper Spiked Kickers",
+          "level": 40,
+          "materials": {
+            "copper-bar": 45000,
+            "leather-straps": 45000,
+            "wildfire": 45000,
+            "milk-of-the-poppy": 45000
+          },
+          "img": "item/30-45/icon_eq_standard_boots_copperspikedkickers.png",
+          "odds": "normal"
+        },
+        {
+          "name": "Black Iron Sabatons",
+          "level": 40,
+          "materials": {
+            "silk": 45000,
+            "black-iron": 45000,
+            "wildfire": 45000,
+            "hide": 45000
+          },
+          "img": "item/30-45/icon_eq_standard_boots_blackironsabatons.png",
+          "odds": "normal"
+        },
+        {
+          "name": "Blackwater Treads",
+          "level": 40,
+          "materials": {
+            "weirwood": 45000,
+            "black-iron": 45000,
+            "hide": 45000,
+            "kingswood-oak": 45000
+          },
+          "img": "item/30-45/icon_eq_standard_boots_blackwatertreads.png",
+          "odds": "normal"
+        },
+        {
+          "name": "Sapphire Ring",
+          "level": 40,
+          "materials": {
+            "dragonglass": 45000,
+            "weirwood": 45000,
+            "hide": 45000,
+            "milk-of-the-poppy": 45000
+          },
+          "img": "item/30-45/icon_eq_standard_ring_sapphire.png",
+          "odds": "normal"
+        },
+        {
+          "name": "Ruby Ring",
+          "level": 40,
+          "materials": {
+            "dragonglass": 45000,
+            "kingswood-oak": 45000,
+            "silk": 45000,
+            "milk-of-the-poppy": 45000
+          },
+          "img": "item/30-45/icon_eq_standard_ring_ruby.png",
+          "odds": "normal"
+        },
+        {
+          "name": "Iron Ring",
+          "level": 40,
+          "materials": {
+            "black-iron": 45000,
+            "leather-straps": 45000,
+            "ironwood": 45000,
+            "goldenheart-wood": 45000
+          },
+          "img": "item/30-45/icon_eq_standard_ring_ironring.png",
+          "odds": "normal"
+        },
+        {
+          "name": "heavy Crossbow",
+          "level": 40,
+          "materials": {
+            "weirwood": 45000,
+            "leather-straps": 45000,
+            "hide": 45000,
+            "dragonglass": 45000
+          },
+          "img": "item/30-45/icon_eq_standard_weapon_heavycrossbow.png",
+          "odds": "normal"
+        },
+        {
+          "name": "Long Sword",
+          "level": 40,
+          "materials": {
+            "weirwood": 45000,
+            "kingswood-oak": 45000,
+            "copper-bar": 45000,
+            "black-iron": 45000
+          },
+          "img": "item/30-45/icon_eq_standard_weapon_longsword.png",
+          "odds": "normal"
+        },
+        {
+          "name": "Poleaxe",
+          "level": 40,
+          "materials": {
+            "goldenheart-wood": 45000,
+            "kingswood-oak": 45000,
+            "black-iron": 45000,
+            "leather-straps": 45000
+          },
+          "img": "item/30-45/icon_eq_standard_weapon_poleaxe.png",
+          "odds": "normal"
+        },
+        {
+          "name": "Jewl Encrusted Tiara",
+          "level": 45,
+          "materials": {
+            "dragonglass": 120000,
+            "wildfire": 120000,
+            "kingswood-oak": 120000,
+            "silk": 120000
+          },
+          "img": "item/30-45/icon_eq_standard_helmet_jewelencrustedtiara.png",
+          "odds": "normal"
+        },
+        {
+          "name": "Assassin's Cowl",
+          "level": 45,
+          "materials": {
+            "silk": 120000,
+            "leather-straps": 120000,
+            "hide": 120000,
+            "kingswood-oak": 120000
+          },
+          "img": "item/30-45/icon_eq_standard_helmet_assassinscowl.png",
+          "odds": "normal"
+        },
+        {
+          "name": "Sapphire Forehead Pendant",
+          "level": 45,
+          "materials": {
+            "dragonglass": 120000,
+            "ironwood": 120000,
+            "kingswood-oak": 120000,
+            "hide": 120000
+          },
+          "img": "item/30-45/icon_eq_standard_helmet_sapphireforeheadpendant.png",
+          "odds": "normal"
+        },
+        {
+          "name": "Golden Raiment",
+          "level": 45,
+          "materials": {
+            "goldenheart-wood": 120000,
+            "copper-bar": 120000,
+            "weirwood": 120000,
+            "ironwood": 120000
+          },
+          "img": "item/30-45/icon_eq_standard_chest_goldenraiment.png",
+          "odds": "normal"
+        },
+        {
+          "name": "Bronze Cuirass",
+          "level": 45,
+          "materials": {
+            "ironwood": 120000,
+            "kingswood-oak": 120000,
+            "hide": 120000,
+            "dragonglass": 120000
+          },
+          "img": "item/30-45/icon_eq_standard_chest_bronzecuirass.png",
+          "odds": "normal"
+        },
+        {
+          "name": "Lead Cuirass",
+          "level": 45,
+          "materials": {
+            "black-iron": 120000,
+            "weirwood": 120000,
+            "silk": 120000,
+            "goldenheart-wood": 120000
+          },
+          "img": "item/30-45/icon_eq_standard_chest_leadcuirass.png",
+          "odds": "normal"
+        },
+        {
+          "name": "Steel Greaves",
+          "level": 45,
+          "materials": {
+            "black-iron": 120000,
+            "ironwood": 120000,
+            "weirwood": 120000,
+            "goldenheart-wood": 120000
+          },
+          "img": "item/30-45/icon_eq_standard_pants_steelgreaves.png",
+          "odds": "normal"
+        },
+        {
+          "name": "Wolf Pelt Trousers",
+          "level": 45,
+          "materials": {
+            "hide": 120000,
+            "kingswood-oak": 120000,
+            "silk": 120000,
+            "milk-of-the-poppy": 120000
+          },
+          "img": "item/30-45/icon_eq_standard_pants_wolfpelttrousers.png",
+          "odds": "normal"
+        },
+        {
+          "name": "Satin Skirt",
+          "level": 45,
+          "materials": {
+            "silk": 120000,
+            "milk-of-the-poppy": 120000,
+            "kingswood-oak": 120000,
+            "copper-bar": 120000
+          },
+          "img": "item/30-45/icon_eq_standard_pants_satinskirt.png",
+          "odds": "normal"
+        },
+        {
+          "name": "Lead Soled Shoes",
+          "level": 45,
+          "materials": {
+            "kingswood-oak": 120000,
+            "black-iron": 120000,
+            "weirwood": 120000,
+            "copper-bar": 120000
+          },
+          "img": "item/30-45/icon_eq_standard_boots_leadsoledshoes.png",
+          "odds": "normal"
+        },
+        {
+          "name": "Copper Sabatons",
+          "level": 45,
+          "materials": {
+            "copper-bar": 120000,
+            "ironwood": 120000,
+            "kingswood-oak": 120000,
+            "milk-of-the-poppy": 120000
+          },
+          "img": "item/30-45/icon_eq_standard_boots_coppersabatons.png",
+          "odds": "normal"
+        },
+        {
+          "name": "Spurred Treads",
+          "level": 45,
+          "materials": {
+            "ironwood": 120000,
+            "dragonglass": 120000,
+            "goldenheart-wood": 120000,
+            "hide": 120000
+          },
+          "img": "item/30-45/icon_eq_standard_boots_spurredtreads.png",
+          "odds": "normal"
+        },
+        {
+          "name": "Pearl Ring",
+          "level": 45,
+          "materials": {
+            "dragonglass": 120000,
+            "hide": 120000,
+            "ironwood": 120000,
+            "goldenheart-wood": 120000
+          },
+          "img": "item/30-45/icon_eq_standard_ring_pearl.png",
+          "odds": "normal"
+        },
+        {
+          "name": "Emerald Ring",
+          "level": 45,
+          "materials": {
+            "dragonglass": 120000,
+            "weirwood": 120000,
+            "milk-of-the-poppy": 120000,
+            "goldenheart-wood": 120000
+          },
+          "img": "item/30-45/icon_eq_standard_ring_emerald.png",
+          "odds": "normal"
+        },
+        {
+          "name": "Gold Loop",
+          "level": 45,
+          "materials": {
+            "copper-bar": 120000,
+            "weirwood": 120000,
+            "silk": 120000,
+            "milk-of-the-poppy": 120000
+          },
+          "img": "item/30-45/icon_eq_standard_ring_goldloop.png",
+          "odds": "normal"
+        },
+        {
+          "name": "Triple Crossbow",
+          "level": 45,
+          "materials": {
+            "goldenheart-wood": 120000,
+            "kingswood-oak": 120000,
+            "weirwood": 120000,
+            "ironwood": 120000
+          },
+          "img": "item/30-45/icon_eq_standard_weapon_triplecrossbow.png",
+          "odds": "normal"
+        },
+        {
+          "name": "Morningstar",
+          "level": 45,
+          "materials": {
+            "ironwood": 120000,
+            "kingswood-oak": 120000,
+            "hide": 120000,
+            "wildfire": 120000
+          },
+          "img": "item/30-45/icon_eq_standard_weapon_morningstar.png",
+          "odds": "normal"
+        },
+        {
+          "name": "Battle Axe",
+          "level": 45,
+          "materials": {
+            "weirwood": 120000,
+            "copper-bar": 120000,
+            "silk": 120000,
+            "goldenheart-wood": 120000
+          },
+          "img": "item/30-45/icon_eq_standard_weapon_battleaxe.png",
+          "odds": "normal"
+        }
+      ]
+    }
+  ]
+};

--- a/seasons/seasonctw.js
+++ b/seasons/seasonctw.js
@@ -1,0 +1,801 @@
+const seasonctw = {
+  "season": 3,
+  "sets": [
+    {
+      "setName": "Ceremonial Targaryen Warlord",
+      "products": [
+        {
+          "name": "Helm",
+          "level": 1,
+          "materials": {
+            "silk": 6,
+            "black-iron": 6,
+            "copper-bar": 6
+          },
+          "img": "item/ctw-head.png",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Chestplate",
+          "level": 1,
+          "materials": {
+            "milk-of-the-poppy": 6,
+            "hide": 6,
+            "ironwood": 6
+          },
+          "img": "item/ctw-chest.png",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Pants",
+          "level": 1,
+          "materials": {
+            "kingswood-oak": 6,
+            "wildfire": 6,
+            "hide": 6
+          },
+          "img": "item/ctw-pants.png",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Sword",
+          "level": 1,
+          "materials": {
+            "ironwood": 6,
+            "goldenheart-wood": 6,
+            "wildfire": 6
+          },
+          "img": "item/ctw-weapon.png",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Ring",
+          "level": 1,
+          "materials": {
+            "weirwood": 6,
+            "leather-straps": 6,
+            "black-iron": 6
+          },
+          "img": "item/ctw-ring.png",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Boots",
+          "level": 1,
+          "materials": {
+            "ironwood": 6,
+            "goldenheart-wood": 6,
+            "wildfire": 6
+          },
+          "img": "item/ctw-boots.png",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Helm",
+          "level": 5,
+          "materials": {
+            "kingswood-oak": 10,
+            "wildfire": 10,
+            "hide": 10
+          },
+          "img": "item/ctw-head.png",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Chestplate",
+          "level": 5,
+          "materials": {
+            "silk": 10,
+            "black-iron": 10,
+            "copper-bar": 10
+          },
+          "img": "item/ctw-chest.png",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Pants",
+          "level": 5,
+          "materials": {
+            "weirwood": 10,
+            "leather-straps": 10,
+            "black-iron": 10
+          },
+          "img": "item/ctw-pants.png",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Sword",
+          "level": 5,
+          "materials": {
+            "copper-bar": 10,
+            "dragonglass": 10,
+            "leather-straps": 10
+          },
+          "img": "item/ctw-weapon.png",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Ring",
+          "level": 5,
+          "materials": {
+            "ironwood": 10,
+            "goldenheart-wood": 10,
+            "wildfire": 10
+          },
+          "img": "item/ctw-ring.png",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Boots",
+          "level": 5,
+          "materials": {
+            "milk-of-the-poppy": 10,
+            "hide": 10,
+            "ironwood": 10
+          },
+          "img": "item/ctw-boots.png",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Helm",
+          "level": 10,
+          "materials": {
+            "kingswood-oak": 20,
+            "wildfire": 20,
+            "hide": 20
+          },
+          "img": "item/ctw-head.png",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Chestplate",
+          "level": 10,
+          "materials": {
+            "silk": 20,
+            "black-iron": 20,
+            "copper-bar": 20
+          },
+          "img": "item/ctw-chest.png",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Pants",
+          "level": 10,
+          "materials": {
+            "weirwood": 20,
+            "leather-straps": 20,
+            "black-iron": 20
+          },
+          "img": "item/ctw-pants.png",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Sword",
+          "level": 10,
+          "materials": {
+            "copper-bar": 20,
+            "dragonglass": 20,
+            "leather-straps": 20
+          },
+          "img": "item/ctw-weapon.png",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Ring",
+          "level": 10,
+          "materials": {
+            "ironwood": 20,
+            "goldenheart-wood": 20,
+            "wildfire": 20
+          },
+          "img": "item/ctw-ring.png",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Boots",
+          "level": 10,
+          "materials": {
+            "milk-of-the-poppy": 20,
+            "hide": 20,
+            "ironwood": 20
+          },
+          "img": "item/ctw-boots.png",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Helm",
+          "level": 15,
+          "materials": {
+            "kingswood-oak": 120,
+            "wildfire": 120,
+            "hide": 120
+          },
+          "img": "item/ctw-head.png",
+          "odds": "normal",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Chestplate",
+          "level": 15,
+          "materials": {
+            "silk": 120,
+            "black-iron": 120,
+            "copper-bar": 120
+          },
+          "img": "item/ctw-chest.png",
+          "odds": "normal",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Pants",
+          "level": 15,
+          "materials": {
+            "weirwood": 120,
+            "leather-straps": 120,
+            "black-iron": 120
+          },
+          "img": "item/ctw-pants.png",
+          "odds": "normal",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Sword",
+          "level": 15,
+          "materials": {
+            "copper-bar": 120,
+            "dragonglass": 120,
+            "leather-straps": 120
+          },
+          "img": "item/ctw-weapon.png",
+          "odds": "normal",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Ring",
+          "level": 15,
+          "materials": {
+            "ironwood": 120,
+            "goldenheart-wood": 120,
+            "wildfire": 120
+          },
+          "img": "item/ctw-ring.png",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Boots",
+          "level": 15,
+          "materials": {
+            "milk-of-the-poppy": 120,
+            "hide": 120,
+            "ironwood": 120
+          },
+          "img": "item/ctw-boots.png",
+          "odds": "normal",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Helm",
+          "level": 20,
+          "materials": {
+            "kingswood-oak": 400,
+            "wildfire": 400,
+            "hide": 400
+          },
+          "img": "item/ctw-head.png",
+          "odds": "medium",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Chestplate",
+          "level": 20,
+          "materials": {
+            "silk": 400,
+            "black-iron": 400,
+            "copper-bar": 400
+          },
+          "img": "item/ctw-chest.png",
+          "odds": "medium",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Pants",
+          "level": 20,
+          "materials": {
+            "weirwood": 400,
+            "leather-straps": 400,
+            "black-iron": 400
+          },
+          "img": "item/ctw-pants.png",
+          "odds": "medium",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Sword",
+          "level": 20,
+          "materials": {
+            "copper-bar": 400,
+            "dragonglass": 400,
+            "leather-straps": 400
+          },
+          "img": "item/ctw-weapon.png",
+          "odds": "medium",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Ring",
+          "level": 20,
+          "materials": {
+            "ironwood": 400,
+            "goldenheart-wood": 400,
+            "wildfire": 400
+          },
+          "img": "item/ctw-ring.png",
+          "odds": "medium",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Boots",
+          "level": 20,
+          "materials": {
+            "milk-of-the-poppy": 400,
+            "hide": 400,
+            "ironwood": 400
+          },
+          "img": "item/ctw-boots.png",
+          "odds": "medium",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Helm",
+          "level": 25,
+          "materials": {
+            "kingswood-oak": 1200,
+            "wildfire": 1200,
+            "hide": 1200,
+            "milk-of-the-poppy": 1200
+          },
+          "img": "item/ctw-head.png",
+          "odds": "normal",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Chestplate",
+          "level": 25,
+          "materials": {
+            "silk": 1200,
+            "black-iron": 1200,
+            "copper-bar": 1200,
+            "dragonglass": 1200
+          },
+          "img": "item/ctw-chest.png",
+          "odds": "normal",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Pants",
+          "level": 25,
+          "materials": {
+            "weirwood": 1200,
+            "leather-straps": 1200,
+            "black-iron": 1200,
+            "silk": 1200
+          },
+          "img": "item/ctw-pants.png",
+          "odds": "normal",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Sword",
+          "level": 25,
+          "materials": {
+            "copper-bar": 1200,
+            "dragonglass": 1200,
+            "leather-straps": 1200,
+            "weirwood": 1200
+          },
+          "img": "item/ctw-weapon.png",
+          "odds": "normal",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Ring",
+          "level": 25,
+          "materials": {
+            "ironwood": 1200,
+            "goldenheart-wood": 1200,
+            "wildfire": 1200,
+            "kingswood-oak": 1200
+          },
+          "img": "item/ctw-ring.png",
+          "odds": "normal",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Boots",
+          "level": 25,
+          "materials": {
+            "milk-of-the-poppy": 1200,
+            "hide": 1200,
+            "ironwood": 1200,
+            "goldenheart-wood": 1200
+          },
+          "img": "item/ctw-boots.png",
+          "odds": "normal",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Helm",
+          "level": 30,
+          "materials": {
+            "kingswood-oak": 3000,
+            "wildfire": 3000,
+            "hide": 3000,
+            "milk-of-the-poppy": 3000
+          },
+          "img": "item/ctw-head.png",
+          "odds": "normal",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Chestplate",
+          "level": 30,
+          "materials": {
+            "silk": 3000,
+            "black-iron": 3000,
+            "copper-bar": 3000,
+            "dragonglass": 3000
+          },
+          "img": "item/ctw-chest.png",
+          "odds": "normal",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Pants",
+          "level": 30,
+          "materials": {
+            "weirwood": 3000,
+            "leather-straps": 3000,
+            "black-iron": 3000,
+            "silk": 3000
+          },
+          "img": "item/ctw-pants.png",
+          "odds": "normal",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Sword",
+          "level": 30,
+          "materials": {
+            "copper-bar": 3000,
+            "dragonglass": 3000,
+            "leather-straps": 3000,
+            "weirwood": 3000
+          },
+          "img": "item/ctw-weapon.png",
+          "odds": "normal",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Ring",
+          "level": 30,
+          "materials": {
+            "ironwood": 3000,
+            "goldenheart-wood": 3000,
+            "wildfire": 3000,
+            "kingswood-oak": 3000
+          },
+          "img": "item/ctw-ring.png",
+          "odds": "normal",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Boots",
+          "level": 30,
+          "materials": {
+            "milk-of-the-poppy": 3000,
+            "hide": 3000,
+            "ironwood": 3000,
+            "goldenheart-wood": 3000
+          },
+          "img": "item/ctw-boots.png",
+          "odds": "normal",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Helm",
+          "level": 35,
+          "materials": {
+            "kingswood-oak": 12000,
+            "wildfire": 12000,
+            "hide": 12000,
+            "milk-of-the-poppy": 12000
+          },
+          "img": "item/ctw-head.png",
+          "odds": "normal",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Chestplate",
+          "level": 35,
+          "materials": {
+            "silk": 12000,
+            "black-iron": 12000,
+            "copper-bar": 12000,
+            "dragonglass": 12000
+          },
+          "img": "item/ctw-chest.png",
+          "odds": "normal",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Pants",
+          "level": 35,
+          "materials": {
+            "weirwood": 12000,
+            "leather-straps": 12000,
+            "black-iron": 12000,
+            "silk": 12000
+          },
+          "img": "item/ctw-pants.png",
+          "odds": "normal",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Sword",
+          "level": 35,
+          "materials": {
+            "copper-bar": 12000,
+            "dragonglass": 12000,
+            "leather-straps": 12000,
+            "weirwood": 12000
+          },
+          "img": "item/ctw-weapon.png",
+          "odds": "normal",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Ring",
+          "level": 35,
+          "materials": {
+            "ironwood": 12000,
+            "goldenheart-wood": 12000,
+            "wildfire": 12000,
+            "kingswood-oak": 12000
+          },
+          "img": "item/ctw-ring.png",
+          "odds": "normal",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Boots",
+          "level": 35,
+          "materials": {
+            "milk-of-the-poppy": 12000,
+            "hide": 12000,
+            "ironwood": 12000,
+            "goldenheart-wood": 12000
+          },
+          "img": "item/ctw-boots.png",
+          "odds": "normal",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Helm",
+          "level": 40,
+          "materials": {
+            "kingswood-oak": 45000,
+            "wildfire": 45000,
+            "hide": 45000,
+            "milk-of-the-poppy": 45000
+          },
+          "img": "item/ctw-head.png",
+          "odds": "normal",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Chestplate",
+          "level": 40,
+          "materials": {
+            "silk": 45000,
+            "black-iron": 45000,
+            "copper-bar": 45000,
+            "dragonglass": 45000
+          },
+          "img": "item/ctw-chest.png",
+          "odds": "normal",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Pants",
+          "level": 40,
+          "materials": {
+            "weirwood": 45000,
+            "leather-straps": 45000,
+            "black-iron": 45000,
+            "silk": 45000
+          },
+          "img": "item/ctw-pants.png",
+          "odds": "normal",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Sword",
+          "level": 40,
+          "materials": {
+            "copper-bar": 45000,
+            "dragonglass": 45000,
+            "leather-straps": 45000,
+            "weirwood": 45000
+          },
+          "img": "item/ctw-weapon.png",
+          "odds": "normal",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Ring",
+          "level": 40,
+          "materials": {
+            "ironwood": 45000,
+            "goldenheart-wood": 45000,
+            "wildfire": 45000,
+            "kingswood-oak": 45000
+          },
+          "img": "item/ctw-ring.png",
+          "odds": "normal",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Boots",
+          "level": 40,
+          "materials": {
+            "milk-of-the-poppy": 45000,
+            "hide": 45000,
+            "ironwood": 45000,
+            "goldenheart-wood": 45000
+          },
+          "img": "item/ctw-boots.png",
+          "odds": "normal",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Helm",
+          "level": 45,
+          "materials": {
+            "kingswood-oak": 120000,
+            "wildfire": 120000,
+            "hide": 120000,
+            "milk-of-the-poppy": 120000
+          },
+          "img": "item/ctw-head.png",
+          "odds": "normal",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Chestplate",
+          "level": 45,
+          "materials": {
+            "silk": 120000,
+            "black-iron": 120000,
+            "copper-bar": 120000,
+            "dragonglass": 120000
+          },
+          "img": "item/ctw-chest.png",
+          "odds": "normal",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Pants",
+          "level": 45,
+          "materials": {
+            "weirwood": 120000,
+            "leather-straps": 120000,
+            "black-iron": 120000,
+            "silk": 120000
+          },
+          "img": "item/ctw-pants.png",
+          "odds": "normal",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Sword",
+          "level": 45,
+          "materials": {
+            "copper-bar": 120000,
+            "dragonglass": 120000,
+            "leather-straps": 120000,
+            "weirwood": 120000
+          },
+          "img": "item/ctw-weapon.png",
+          "odds": "normal",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Ring",
+          "level": 45,
+          "materials": {
+            "ironwood": 120000,
+            "goldenheart-wood": 120000,
+            "wildfire": 120000,
+            "kingswood-oak": 120000
+          },
+          "img": "item/ctw-ring.png",
+          "odds": "normal",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        },
+        {
+          "name": "Boots",
+          "level": 45,
+          "materials": {
+            "milk-of-the-poppy": 120000,
+            "hide": 120000,
+            "ironwood": 120000,
+            "goldenheart-wood": 120000
+          },
+          "img": "item/ctw-boots.png",
+          "odds": "normal",
+          "warlord": true,
+          "setName": "Ceremonial Targaryen Warlord"
+        }
+      ]
+    }
+  ]
+};


### PR DESCRIPTION
## Summary
- remove Ceremonial Targaryen Warlord items from the season 0 data file
- add a dedicated `seasonctw` dataset and include it when loading products
- load the new dataset in the page so CTW items stay available without affecting season 0 weighting

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e0ecd8428883229c42ff4c5ae224f7