### PR TITLE
Stop auto opening update log overlay

### DIFF
--- a/craftparse.js
+++ b/craftparse.js
@@ -160,6 +160,14 @@ function initializeUpdateLog() {
     const storageSupported = isLocalStorageAvailable();
     const hasSeenUpdate = storageSupported ? window.localStorage.getItem(storageKey) === 'seen' : false;
 
+    const setUpdateIndicator = (hasUpdate) => {
+        if (hasUpdate) {
+            trigger.setAttribute('data-has-update', 'true');
+        } else {
+            trigger.removeAttribute('data-has-update');
+        }
+    };
+
     const markSeen = () => {
         if (storageSupported) {
             try {
@@ -168,6 +176,7 @@ function initializeUpdateLog() {
                 // Ignore storage failures silently
             }
         }
+        setUpdateIndicator(false);
     };
 
     const setExpandedState = (expanded) => {
@@ -178,6 +187,7 @@ function initializeUpdateLog() {
         overlay.style.display = 'flex';
         overlay.setAttribute('aria-hidden', 'false');
         setExpandedState(true);
+        setUpdateIndicator(false);
     };
 
     const closeOverlay = (shouldMarkSeen = false) => {
@@ -189,9 +199,7 @@ function initializeUpdateLog() {
         }
     };
 
-    if (!hasSeenUpdate) {
-        openOverlay();
-    }
+    setUpdateIndicator(!hasSeenUpdate);
 
     const setPanelState = (button, expanded) => {
         const panelId = button.getAttribute('aria-controls');

--- a/style.css
+++ b/style.css
@@ -462,12 +462,25 @@ button.info-btn:hover {
     margin: 0;
     height: 30px;
     width: 30px;
+    position: relative;
 }
 
 .update-log-trigger button svg {
     width: 22px;
     height: 22px;
     fill: currentColor;
+}
+
+.update-log-trigger button[data-has-update="true"]::after {
+    content: "";
+    position: absolute;
+    top: 2px;
+    right: 2px;
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: var(--button-bg);
+    box-shadow: 0 0 0 2px #fff;
 }
 
 .update-log-trigger button:hover,


### PR DESCRIPTION
## Summary
- prevent the update log overlay from opening automatically on load
- show a badge on the update log button until the newest entry has been acknowledged

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e402a59b2c83228985f9623abbb1ea