### PR TITLE
Add scoring explanation and logging for product selection

### DIFF
--- a/craftparse.js
+++ b/craftparse.js
@@ -1166,9 +1166,16 @@ function renderResults(templateCounts, materialCounts) {
 
     resultsDiv.appendChild(materialsDiv);
 
+    const scoringExplanation = document.createElement('div');
+    scoringExplanation.className = 'score-explanation';
+    scoringExplanation.innerHTML = `
+        <h3>Pisteytyksen tiivistelmä</h3>
+        <p>Jokaisen tuotteen pistemäärä muodostuu materiaalien saatavuudesta: runsaimmat perusmateriaalit antavat +12 pistettä ja gear-materiaalit +6 pistettä, kun taas harvinaisimpia materiaaleja vältetään -10 miinuksella. Gear-tuotteille lisätään vielä oma perusbonus, jotta ne kilpailevat tasaisesti muiden kanssa.</p>
+        <p>Pisteitä pienennetään, jos varasto hupenisi liikaa tai jos materiaalien käyttö painottuu epätasaisesti, ja Warlord-statuksella on oma vähennyksensä. Season 0 -liukusäädin lisää bonuksen vain Season 0 -tuotteille, mutta kokonaispisteet ratkaisevat yhä materiaalien tasapainon ja saatavuuden perusteella, joten myös muiden kausien tuotteet voivat nousta esiin.</p>
+    `;
+
     const generateDiv = document.createElement('div');
     generateDiv.className = 'generate';
-    materialsDiv.after(generateDiv);
 
     const levelItemCounts = calculateTotalItemsByLevel(templateCounts);
     const allSameCount = areAllCountsSame(levelItemCounts);
@@ -1194,9 +1201,11 @@ function renderResults(templateCounts, materialCounts) {
             });
         }
         materialsDiv.after(totalTemplatesHeader);
-        totalTemplatesHeader.after(generateDiv);
+        totalTemplatesHeader.after(scoringExplanation);
+        scoringExplanation.after(generateDiv);
     } else {
-        materialsDiv.after(generateDiv);
+        materialsDiv.after(scoringExplanation);
+        scoringExplanation.after(generateDiv);
     }
 
     const itemsDiv = document.createElement('div');
@@ -1606,6 +1615,30 @@ function shouldApplyOddsForProduct(product) {
 async function calculateProductionPlan(availableMaterials, templatesByLevel, progressTick = async () => {}) {
     const productionPlan = { "1": [], "5": [], "10": [], "15": [], "20": [], "25": [], "30": [], "35": [], "40": [], "45": [] };
     const failed = new Set();
+    const levelScoreLog = {};
+    const loggedLevelSummary = new Set();
+    const formatScore = (value) => (Number.isInteger(value) ? `${value}` : value.toFixed(2));
+    const recordSelection = (level, product, score) => {
+        if (!levelScoreLog[level]) {
+            levelScoreLog[level] = [];
+        }
+        levelScoreLog[level].push(score);
+        console.log(`Level ${level} - ${product.name} - ${formatScore(score)}`);
+    };
+    const logLevelSummary = (level) => {
+        if (loggedLevelSummary.has(level)) {
+            return;
+        }
+        const scores = levelScoreLog[level];
+        if (!scores || scores.length === 0) {
+            return;
+        }
+        const maxScore = Math.max(...scores);
+        const minScore = Math.min(...scores);
+        console.log(`Korkein valittu pistemäärä: ${formatScore(maxScore)} (Level ${level})`);
+        console.log(`Alin valittu pistemäärä: ${formatScore(minScore)} (Level ${level})`);
+        loggedLevelSummary.add(level);
+    };
     const includeWarlords = document.getElementById('includeWarlords')?.checked ?? true;
     const level1OnlyWarlords = document.getElementById('level1OnlyWarlords')?.checked ?? false;
     const level20OnlyWarlords = document.getElementById('level20OnlyWarlords')?.checked ?? false;
@@ -1697,10 +1730,19 @@ async function calculateProductionPlan(availableMaterials, templatesByLevel, pro
                 );
 
                 if (selected && canProductBeProduced(selected, availableMaterials, multiplier)) {
+                    const score = getMaterialScore(
+                        selected,
+                        prefs.mostAvailableMaterials,
+                        prefs.secondMostAvailableMaterials,
+                        prefs.leastAvailableMaterials,
+                        availableMaterials,
+                        multiplier
+                    );
+                    recordSelection(level, selected, score);
                     productionPlan[level].push({ name: selected.name, season: selected.season, setName: selected.setName, warlord: selected.warlord });
                     updateAvailableMaterials(availableMaterials, selected, multiplier);
                     remaining--;
-					produced++;
+                    produced++;
                     await progress();
                 } else {
                     break;
@@ -1710,6 +1752,9 @@ async function calculateProductionPlan(availableMaterials, templatesByLevel, pro
             templatesByLevel[level] = remaining;
 
             if (produced > 0) {
+                if (remaining === 0) {
+                    logLevelSummary(level);
+                }
                 return;
             }
         }
@@ -1755,9 +1800,21 @@ async function calculateProductionPlan(availableMaterials, templatesByLevel, pro
             );
 
             if (selectedProduct && canProductBeProduced(selectedProduct, availableMaterials, multiplier)) {
+                const score = getMaterialScore(
+                    selectedProduct,
+                    preferences.mostAvailableMaterials,
+                    preferences.secondMostAvailableMaterials,
+                    preferences.leastAvailableMaterials,
+                    availableMaterials,
+                    multiplier
+                );
+                recordSelection(level, selectedProduct, score);
                 productionPlan[level].push({ name: selectedProduct.name, season: selectedProduct.season, setName: selectedProduct.setName, warlord: selectedProduct.warlord });
                 updateAvailableMaterials(availableMaterials, selectedProduct, multiplier);
                 remaining[level]--;
+                if (remaining[level] === 0) {
+                    logLevelSummary(level);
+                }
                 anySelected = true;
                 await progress();
             } else {
@@ -1770,6 +1827,12 @@ async function calculateProductionPlan(availableMaterials, templatesByLevel, pro
             break;
         }
     }
+
+    LEVELS.forEach(level => {
+        if (remaining[level] === 0) {
+            logLevelSummary(level);
+        }
+    });
 
     return { plan: productionPlan, failedLevels: Array.from(failed) };
 }

--- a/style.css
+++ b/style.css
@@ -311,6 +311,22 @@ p.craft-extra-info {
     text-align: center;
 }
 
+.score-explanation {
+    background: #ffffff;
+    border: 1px solid rgba(8, 66, 90, 0.15);
+    border-radius: 10px;
+    margin: 20px 0;
+    padding: 18px 20px;
+    line-height: 1.6;
+    color: #1f2c33;
+}
+
+.score-explanation h3 {
+    margin-top: 0;
+    margin-bottom: 10px;
+    color: var(--primary-color);
+}
+
 .section-title {
     display: flex;
     align-items: center;


### PR DESCRIPTION
## Summary
- add an in-app explanation of the scoring logic next to the generated materials list
- style the new explanation block to match the existing results view
- log each selected product's score plus the highest and lowest scores per level to the console for easier debugging

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e4a8be56088322a3a775be5926c051